### PR TITLE
Implement uploading to codecov.io via external action

### DIFF
--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -23,11 +23,13 @@ runs:
       shell: bash
       name: Run unit tests with coverage
       working-directory: ${{ github.workspace }}
-    - run: export CODECOV_TOKEN="${{ inputs.token }}"
+    - run:  poetry run coverage xml
       shell: bash
-      name: export codecoverage token
+      name: Create coverage XML report
       working-directory: ${{ github.workspace }}
-    - run: poetry run codecov
-      shell: bash
+    - uses: codecov/codecov-action@v2
+      with:
+        token: ${{ inputs.token }}
+        fail_ci_if_error: true
+      working-directory: ${{ github.workspace }}
       name: Upload coverage to codecov.io
-      working-directory: ${{ github.workspace }}


### PR DESCRIPTION
**What**:

GitHub supports to reference other actions in composite actions now.
Therefore switch to use codecov.io upload action instead of using the
deprecated python script.

**Why**:

Action composition is now possible and codecov python tool is deprecated.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
