### PR TITLE
[Workflows]: clean up - run only if changes related

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, "v*" ]
     # only run if a file in backport-pull-request has changed
-    paths: ["backport-pull-request/**"]
+    paths: [ "backport-pull-request/**", ".github/workflows/container.yml" ]
     tags: ["v*"]
   workflow_dispatch:
 

--- a/.github/workflows/test-container-image-tags.yml
+++ b/.github/workflows/test-container-image-tags.yml
@@ -4,8 +4,10 @@ on:
   push:
     tags: ["*"]
     branches: [main]
+    paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
   pull_request:
     branches: [main]
+    paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
 
 jobs:
   test-reference-version-branch:

--- a/.github/workflows/test-doc-coverage.yml
+++ b/.github/workflows/test-doc-coverage.yml
@@ -4,8 +4,10 @@ on:
   push:
     tags: ["*"]
     branches: [main]
+    paths: [ "doc-coverage-clang/**", ".github/workflows/test-doc-coverage.yml" ]
   pull_request:
     branches: [main]
+    paths: ["doc-coverage-clang/**", ".github/workflows/test-doc-coverage.yml"]
 
 jobs:
   test-doc-cov-clang:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,10 +2,12 @@ name: Test Python Actions
 
 on:
   push:
-    tags: ["*"]
-    branches: [main]
+    tags: [ "*" ]
+    branches: [ main ]
+    paths: [ "poetry/**","poetry/**","coverage-python/**","lint-python/**", ".github/workflows/test-python.yml" ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
+    paths: [ "poetry/**","poetry/**","coverage-python/**","lint-python/**", ".github/workflows/test-python.yml" ]
 
 jobs:
   install-poetry:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -2,10 +2,11 @@ name: Test Release Actions
 
 on:
   push:
-    tags: ["*"]
-    branches: [main]
+    tags: [ "*" ]
+    branches: [ main ]
+    paths: [ "release/**","release-python/**", ".github/workflows/test-release.yml" ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   release-patch-cc:

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 
 node_modules/
 .vscode
+.idea/


### PR DESCRIPTION
**What**:

This changes the that the action only run if it is needed. So the source is changed related to this workflow.

**Why**:

It should be prevented that not needed workflows are triggered if they have to do with the actual commit/push/pullrequest.

**How**:



**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
