### PR TITLE
build(artifacts-download-trigger): commit the build of the distribution file

### DIFF
--- a/.github/workflows/artifacts-download-trigger-build.yml
+++ b/.github/workflows/artifacts-download-trigger-build.yml
@@ -164,3 +164,23 @@ jobs:
         with:
           expected: failure
           actual: ${{ steps.timeout-workflow.outcome }}
+
+  build-dist:
+    needs: [ build, timeout-test, failing-test, long-running-test, echo-2-test, echo-1-test ]
+    runs-on: ubuntu-latest
+    name: "Commit dist of this action to the repo"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Download dist
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: artifacts-download-trigger/dist
+      - name: Commit dist file of this action
+        run: |
+          git config --global user.name "${{ secrets.GREENBONE_BOT }}"
+          git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
+          git add artifacts-download-trigger/dist/index.js || true
+          git commit -m "New build of artifacts-download-trigger/dist/index.js" || true
+          git push || true


### PR DESCRIPTION
**What**:

Build the artifacts-download-trigger action and commit the dist/index.js to the repo.

**Why**:

Sometimes we miss the build, after we made some changes on the source. 

**How**:


**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] CHANGELOG.md entry N/A
- [ ] Documentation N/A
