### PR TITLE
build(container-image-tags): commit the build of the distribution file

### DIFF
--- a/.github/workflows/test-container-image-tags.yml
+++ b/.github/workflows/test-container-image-tags.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: [main]
     paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
+  workflow_dispatch:
 
 jobs:
   test-reference-version-branch:
@@ -47,6 +48,27 @@ jobs:
           source 'assert.sh'
           assert_eq ${{ env.VERSION }} "main" "not equivalent!"
 
+  build-container-image-tags-action-dist:
+    runs-on: ubuntu-latest
+    name: Test container image tags for branch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: Build with ncc
+        run: |
+          cd container-image-tags
+          yarn install
+          yarn run build
+      - name: Archive dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: container-image-tags/dist
+          retention-days: 1
+
   test-container-image-tags-branch:
     runs-on: ubuntu-latest
     name: Test container image tags for branch
@@ -73,3 +95,25 @@ jobs:
         run: |
           source 'assert.sh'
           assert_eq ${{ steps.container.outputs.image-tags }} "greenbone/actions:unstable" "wrong container tag"
+
+  build-dist:
+    needs: [ build-container-image-tags-action-dist, test-container-image-tags-branch ]
+    runs-on: ubuntu-latest
+    if: github.ref  && github.event_name != 'pull_request'
+    name: "Commit dist of this action to the repo"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Download dist
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: container-image-tags/dist
+      - name: Commit dist file of this action
+        run: |
+          git config --global user.name "${{ secrets.GREENBONE_BOT }}"
+          git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
+          git add container-image-tags/dist/* || true
+          git commit -m "New build of container-image-tags/dist/*" || true
+          remote_repo="https://${GITHUB_ACTOR}:${{secrets.GREENBONE_BOT_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "${remote_repo}" HEAD:${GITHUB_REF} || true


### PR DESCRIPTION
**What**:

Add a build process that will be triggered and commit the dist of the container-image-tags action.

**Why**:

Sometimes we miss to build the source for the release, this will now automatically done and commit to the repo 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] CHANGELOG.md entry N/A
- [ ] Documentation N/A
