### PR TITLE
build(*): build dist files logic

### DIFF
--- a/.github/workflows/artifacts-download-trigger-build.yml
+++ b/.github/workflows/artifacts-download-trigger-build.yml
@@ -2,11 +2,9 @@ name: artifacts-download-trigger Build & Test
 
 on:
   push:
-    branches: [ '*' ]
     paths:
       - 'artifacts-download-trigger/**'
   pull_request:
-    branches: [ '*' ]
     paths:
       - 'artifacts-download-trigger/**'
   workflow_dispatch:

--- a/.github/workflows/artifacts-download-trigger-build.yml
+++ b/.github/workflows/artifacts-download-trigger-build.yml
@@ -2,11 +2,11 @@ name: artifacts-download-trigger Build & Test
 
 on:
   push:
-    branches: [ main, 'feature/*' ]
+    branches: [ '*' ]
     paths:
       - 'artifacts-download-trigger/**'
   pull_request:
-    branches: [ main, 'feature/*' ]
+    branches: [ '*' ]
     paths:
       - 'artifacts-download-trigger/**'
   workflow_dispatch:
@@ -167,7 +167,7 @@ jobs:
 
   build-dist:
     needs: [ build, timeout-test, failing-test, long-running-test, echo-2-test, echo-1-test ]
-    if: github.ref  && github.event_name != 'pull_request'
+    if: github.ref  && github.event_name != 'pull_request' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     name: "Commit dist of this action to the repo"
     steps:

--- a/.github/workflows/container-images-tags-build.yml
+++ b/.github/workflows/container-images-tags-build.yml
@@ -2,9 +2,11 @@ name: Build Container Image Tags Actions
 
 on:
   push:
+    branches-ignore:
+      - main
     paths: [ "container-image-tags/**", ".github/workflows/container-image-tags-build.yml" ]
   workflow_dispatch:
-  
+
 jobs:
   build-container-image-tags-action-dist:
     runs-on: ubuntu-latest

--- a/.github/workflows/container-images-tags-build.yml
+++ b/.github/workflows/container-images-tags-build.yml
@@ -1,0 +1,50 @@
+name: Build Container Image Tags Actions
+
+on:
+  push:
+    paths: [ "container-image-tags/**", ".github/workflows/container-image-tags-build.yml" ]
+  workflow_dispatch:
+  
+jobs:
+  build-container-image-tags-action-dist:
+    runs-on: ubuntu-latest
+    name: Test container image tags for branch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: Build with ncc
+        run: |
+          cd container-image-tags
+          yarn install
+          yarn run build
+      - name: Archive dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: container-image-tags/dist
+          retention-days: 1
+
+  build-dist:
+    needs: [ build-container-image-tags-action-dist, test-container-image-tags-branch ]
+    runs-on: ubuntu-latest
+    if: github.ref  && github.event_name != 'pull_request' && github.ref != 'refs/heads/main'
+    name: "Commit dist of this action to the repo"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Download dist
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: container-image-tags/dist
+      - name: Commit dist file of this action
+        run: |
+          git config --global user.name "${{ secrets.GREENBONE_BOT }}"
+          git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
+          git add container-image-tags/dist/* || true
+          git commit -m "New build of container-image-tags/dist/*" || true
+          remote_repo="https://${GITHUB_ACTOR}:${{secrets.GREENBONE_BOT_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "${remote_repo}" HEAD:${GITHUB_REF} || true

--- a/.github/workflows/test-container-image-tags.yml
+++ b/.github/workflows/test-container-image-tags.yml
@@ -2,11 +2,11 @@ name: Test Container Image Tags Actions
 
 on:
   push:
-    tags: ["*"]
-    branches: [main]
+    tags: [ '*' ]
+    branches: [ '*' ]
     paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
   pull_request:
-    branches: [main]
+    branches: [ '*' ]
     paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
   workflow_dispatch:
 
@@ -99,7 +99,7 @@ jobs:
   build-dist:
     needs: [ build-container-image-tags-action-dist, test-container-image-tags-branch ]
     runs-on: ubuntu-latest
-    if: github.ref  && github.event_name != 'pull_request'
+    if: github.ref  && github.event_name != 'pull_request' && github.ref != 'refs/heads/main'
     name: "Commit dist of this action to the repo"
     steps:
       - name: Check out repository

--- a/.github/workflows/test-container-image-tags.yml
+++ b/.github/workflows/test-container-image-tags.yml
@@ -3,10 +3,10 @@ name: Test Container Image Tags Actions
 on:
   push:
     tags: [ '*' ]
-    branches: [ '*' ]
+    branches: [ main ]
     paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ main ]
     paths: [ "reference-version/**", "container-image-tags/**", ".github/workflows/test-container-image-tags.yml" ]
   workflow_dispatch:
 
@@ -48,27 +48,6 @@ jobs:
           source 'assert.sh'
           assert_eq ${{ env.VERSION }} "main" "not equivalent!"
 
-  build-container-image-tags-action-dist:
-    runs-on: ubuntu-latest
-    name: Test container image tags for branch
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - name: Build with ncc
-        run: |
-          cd container-image-tags
-          yarn install
-          yarn run build
-      - name: Archive dist
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: container-image-tags/dist
-          retention-days: 1
-
   test-container-image-tags-branch:
     runs-on: ubuntu-latest
     name: Test container image tags for branch
@@ -95,25 +74,3 @@ jobs:
         run: |
           source 'assert.sh'
           assert_eq ${{ steps.container.outputs.image-tags }} "greenbone/actions:unstable" "wrong container tag"
-
-  build-dist:
-    needs: [ build-container-image-tags-action-dist, test-container-image-tags-branch ]
-    runs-on: ubuntu-latest
-    if: github.ref  && github.event_name != 'pull_request' && github.ref != 'refs/heads/main'
-    name: "Commit dist of this action to the repo"
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Download dist
-        uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: container-image-tags/dist
-      - name: Commit dist file of this action
-        run: |
-          git config --global user.name "${{ secrets.GREENBONE_BOT }}"
-          git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
-          git add container-image-tags/dist/* || true
-          git commit -m "New build of container-image-tags/dist/*" || true
-          remote_repo="https://${GITHUB_ACTOR}:${{secrets.GREENBONE_BOT_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
-          git push "${remote_repo}" HEAD:${GITHUB_REF} || true


### PR DESCRIPTION
build dist files only on branches except the main branch and if it is not a pull_request

**What**:
Allow build dist files only on branches except the main branch and if it is not a pull_request.

**Why**:

With this change we get the the dist build done automatically done, while development and when release to v1 branches.
