### PR TITLE
Add a feature 'download-artifacts-no-trigger' any workflow

### DIFF
--- a/artifacts-download-trigger/action.yml
+++ b/artifacts-download-trigger/action.yml
@@ -86,6 +86,10 @@ inputs:
     description: 'Should the Artifact be downloaded?'
     required: false
     default: 'false'
+  download-artifacts-no-trigger:
+    description: 'Should the Artifact be downloaded, but not triggered?'
+    required: false
+    default: 'false'
   force-trigger:
     description: 'Should the workflow trigger be forced?'
     required: false

--- a/artifacts-download-trigger/dist/index.js
+++ b/artifacts-download-trigger/dist/index.js
@@ -11405,8 +11405,15 @@ function run() {
         const args = utils_1.getArgs();
         try {
             core.debug(`Test DL: ${args.downloadArtifacts ? 'true' : 'false'}`);
-            if (args.downloadArtifacts && !args.forceTrigger) {
-                yield main_dl_1.download();
+            if ((args.downloadArtifacts || args.downloadArtifactsNoTrigger) && !args.forceTrigger) {
+                try {
+                    yield main_dl_1.download();
+                }
+                catch (e) {
+                    if (!args.downloadArtifactsNoTrigger || args.forceTrigger) {
+                        throw 'next step';
+                    }
+                }
             }
             else {
                 throw 'next step';
@@ -11860,6 +11867,8 @@ function getArgs() {
     const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'));
     const downloadArtifactsStr = core.getInput('download-artifacts');
     const downloadArtifacts = downloadArtifactsStr && downloadArtifactsStr === 'true';
+    const downloadArtifactsNoTriggerStr = core.getInput('download-artifacts-no-trigger');
+    const downloadArtifactsNoTrigger = downloadArtifactsNoTriggerStr && downloadArtifactsNoTriggerStr === 'true';
     const forceTriggerStr = core.getInput('force-trigger');
     const forceTrigger = forceTriggerStr && forceTriggerStr === 'true';
     return {
@@ -11876,6 +11885,7 @@ function getArgs() {
         waitForCompletion,
         waitForCompletionTimeout,
         downloadArtifacts,
+        downloadArtifactsNoTrigger,
         forceTrigger
     };
 }

--- a/artifacts-download-trigger/src/index.ts
+++ b/artifacts-download-trigger/src/index.ts
@@ -8,8 +8,14 @@ async function run(): Promise<void> {
   const args = getArgs();
   try {
     core.debug(`Test DL: ${args.downloadArtifacts ? 'true' : 'false'}`)
-    if (args.downloadArtifacts && !args.forceTrigger) {
-      await download()
+    if ((args.downloadArtifacts||args.downloadArtifactsNoTrigger) && !args.forceTrigger) {
+      try {
+        await download()
+      }catch (e) {
+        if (!args.downloadArtifactsNoTrigger || args.forceTrigger){
+          throw 'next step'
+        }
+      }
     } else {
       throw 'next step'
     }

--- a/artifacts-download-trigger/src/utils.ts
+++ b/artifacts-download-trigger/src/utils.ts
@@ -46,6 +46,8 @@ export function getArgs() {
 
   const downloadArtifactsStr = core.getInput('download-artifacts');
   const downloadArtifacts = downloadArtifactsStr && downloadArtifactsStr === 'true';
+  const downloadArtifactsNoTriggerStr = core.getInput('download-artifacts-no-trigger');
+  const downloadArtifactsNoTrigger = downloadArtifactsNoTriggerStr && downloadArtifactsNoTriggerStr === 'true';
   const forceTriggerStr = core.getInput('force-trigger');
   const forceTrigger = forceTriggerStr && forceTriggerStr === 'true';
 
@@ -63,6 +65,7 @@ export function getArgs() {
     waitForCompletion,
     waitForCompletionTimeout,
     downloadArtifacts,
+    downloadArtifactsNoTrigger,
     forceTrigger
   };
 }


### PR DESCRIPTION
**What**:

Add a feature 'download-artifacts-no-trigger' any workflow

**Why**:

sometimes, you should only download, and not trigger the workflow again you run just run.
