### PR TITLE
Fix: Allow to ignore not found workflow

### DIFF
--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -130,6 +130,9 @@ class DownloadArtifacts:
                 status=WorkflowRunStatus.SUCCESS.value,
             )
         except httpx.HTTPStatusError as e:
+            if self.allow_not_found and e.response.status_code == 404:
+                return None
+
             raise DownloadArtifactsError(f"Could not find workflow. {e}") from e
 
         if self.is_debug:


### PR DESCRIPTION
**What**:

Don't raise error if the first workflows request fails with 404 and allow not found is set.

**Why**:

We want to be able to ignore not found workflows

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
