### PR TITLE
Change: Allow other users change the downloaded artifact

### DIFF
--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -169,7 +169,7 @@ class DownloadArtifacts:
                     continue
 
                 print(
-                    f"Downloading artifact {artifact_name} with ID "
+                    f"Downloading artifact '{artifact_name}' with ID "
                     f"{artifact_id}",
                     end=" ",
                 )
@@ -193,7 +193,8 @@ class DownloadArtifacts:
                 print(" done.")
 
                 Console.log(
-                    f"Extracting artifact {artifact_name} to {destination_dir}."
+                    f"Extracting artifact '{artifact_name}' to "
+                    f"'{destination_dir}'."
                 )
 
                 zipfile = ZipFile(temp_file)
@@ -207,11 +208,18 @@ class DownloadArtifacts:
                     adjust_permissions(file_path)
 
     def run(self) -> None:
-        Console.log(
-            f"Download artifacts of workflow '{self.workflow}' in repo "
-            f"'{self.repository}' using branch '{self.branch}' to "
-            f"'{self.download_path}' 🚀."
-        )
+        if self.name:
+            Console.log(
+                f"Download '{self.name}' artifact of workflow '{self.workflow}'"
+                f" in repo '{self.repository}' using branch '{self.branch}' to "
+                f"'{self.download_path}' 🚀."
+            )
+        else:
+            Console.log(
+                f"Download artifacts of workflow '{self.workflow}' in repo "
+                f"'{self.repository}' using branch '{self.branch}' to "
+                f"'{self.download_path}' 🚀."
+            )
 
         run = self.get_newest_workflow_run()
 


### PR DESCRIPTION
**What**:

When running in Docker all code is run a the root user. The workflows are run with a normal system user. Therefore in a workflow it is not possible to write to the created download directory or even move the downloaded artifact. With this change the group and other users are gaining write permissions on all created directories and files.

**Why**:

Allow "normal" workflow commands change the downloaded content.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
