### PR TITLE
Change: Make changing to owner of the downloaded artifacts optional

### DIFF
--- a/download-artifact/README.md
+++ b/download-artifact/README.md
@@ -55,6 +55,7 @@ jobs:
 | name            | Name of the artifact to be downloaded. If not set all artifacts will be downloaded.        | Optional                         |
 | allow-not-found | Set to `true` to not fail if workflow or artifact can not be found.                        | Optional                         |
 | path            | Destination path for the to be downloaded artifact of parent directory if name is not set. | Default: `.` (Current directory) |
+| user            | User ID for ownership of the downloaded artifacts.                                         | Optional                         |
 
 The name input parameter mimics the [actions/download-artifact@v3](https://github.com/actions/download-artifact/tree/v3#download-all-artifacts)
 behavior:

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: "Path where to store the downloaded artifacts."
     required: true
     default: "."
+  user:
+    description: "User ID for ownership of the downloaded artifacts."
+    required: false
 outputs:
   downloaded-artifacts:
     description: List of downloaded artifact names as JSON array string

--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -37,8 +37,6 @@ from pontos.github.api import (
     WorkflowRunStatus,
 )
 
-DEFAULT_USER = 1001
-
 
 def is_event(run: JSON_OBJECT, events: Iterable[str]) -> bool:
     event = run.get("event")
@@ -106,7 +104,7 @@ class DownloadArtifacts:
         if not download_path:
             raise DownloadArtifactsError("Missing path.")
 
-        self.user = user or ActionIO.input("user") or DEFAULT_USER
+        self.user = user or ActionIO.input("user")
 
         self.download_path = Path(download_path)
 
@@ -168,13 +166,15 @@ class DownloadArtifacts:
             Console.warning(
                 f"Could not change permissions of '{file_path}'. Error was {e}."
             )
-        try:
-            shutil.chown(file_path, self.user)
-        except OSError as e:
-            Console.warning(
-                f"Could not change owner of '{file_path}' to user "
-                f"'{self.user}'. Error was {e}."
-            )
+
+        if self.user:
+            try:
+                shutil.chown(file_path, self.user)
+            except OSError as e:
+                Console.warning(
+                    f"Could not change owner of '{file_path}' to user "
+                    f"'{self.user}'. Error was {e}."
+                )
 
     def download_artifacts(
         self, artifacts: Iterable[JSON_OBJECT]


### PR DESCRIPTION
**What**:

Make changing to owner of the downloaded artifacts optional

**Why**:

It seems the default user id is not always 1001 on the runners. Therefore to fix the permission issue we need to set the desired user id via an input variable.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
