### PR TITLE
Change: Repository for download artifacts defaults to current one now

### DIFF
--- a/download-artifact/README.md
+++ b/download-artifact/README.md
@@ -2,10 +2,10 @@
 
 GitHub Action to download artifacts of a workflow run.
 
-For finding a corresponding workflow run currently only workflow runs with
-an event of `schedule` and `workflow_dispatch` are considered. The action
-loads workflow runs with these events and downloads the artifact(s) from the
-newest run.
+For finding a corresponding workflow run currently only successfully finished
+workflow runs with an event of `schedule` and `workflow_dispatch` are
+considered. The action loads workflow runs with these events and downloads the
+artifact(s) from the newest run.
 
 To use this action you need to add the following code to your workflow file
 (for example `.github/workflows/artifacts.yml`):

--- a/download-artifact/README.md
+++ b/download-artifact/README.md
@@ -46,16 +46,16 @@ jobs:
 
 ## Action Configuration
 
-| Input Variable  | Description                                                                                |                                  |
-| --------------- | ------------------------------------------------------------------------------------------ | -------------------------------- |
-| token           | Token required to create the backport pull request                                         | Required                         |
-| repository      | Repository of the workflow to trigger                                                      | Required                         |
-| workflow        | Workflow to trigger. Either a workflow ID or file name, for example `ci.yml`.              | Required                         |
-| branch          | The git branch for the workflow.                                                           | Default: `main`                  |
-| name            | Name of the artifact to be downloaded. If not set all artifacts will be downloaded.        | Optional                         |
-| allow-not-found | Set to `true` to not fail if workflow or artifact can not be found.                        | Optional                         |
-| path            | Destination path for the to be downloaded artifact of parent directory if name is not set. | Default: `.` (Current directory) |
-| user            | User ID for ownership of the downloaded artifacts.                                         | Optional                         |
+| Input Variable  | Description                                                                                |                                                   |
+| --------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| token           | Token required to create the backport pull request                                         | Required                                          |
+| workflow        | Workflow to trigger. Either a workflow ID or file name, for example `ci.yml`.              | Required                                          |
+| repository      | Repository of the workflow to trigger                                                      | Default: `GITHUB_REPOSITORY` (current repository) |
+| branch          | The git branch for the workflow.                                                           | Default: `main`                                   |
+| path            | Destination path for the to be downloaded artifact of parent directory if name is not set. | Default: `.` (Current directory)                  |
+| name            | Name of the artifact to be downloaded. If not set all artifacts will be downloaded.        | Optional                                          |
+| allow-not-found | Set to `true` to not fail if workflow or artifact can not be found.                        | Optional                                          |
+| user            | User ID for ownership of the downloaded artifacts.                                         | Optional                                          |
 
 The name input parameter mimics the [actions/download-artifact@v3](https://github.com/actions/download-artifact/tree/v3#download-all-artifacts)
 behavior:

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: "GitHub Token for authentication"
     required: true
   repository:
-    description: "Repository to download the artifacts from"
-    required: true
+    description: "Repository to download the artifacts from. Defaults to the current repository."
+    required: false
   workflow:
     description: "Workflow to download the artifacts from. Either a workflow ID or file path. For example `ci.yml`."
     required: true

--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -82,6 +82,8 @@ class DownloadArtifacts:
         allow_not_found: Optional[str] = None,
         user: Union[str, int] = None,
     ) -> None:
+        env = GitHubEnvironment()
+
         token = token or ActionIO.input("token")
         if not token:
             raise DownloadArtifactsError("Missing token.")
@@ -94,7 +96,9 @@ class DownloadArtifacts:
         if not self.branch:
             raise DownloadArtifactsError("Missing branch.")
 
-        self.repository = repository or ActionIO.input("repository")
+        self.repository = (
+            repository or ActionIO.input("repository") or env.repository
+        )
         if not self.repository:
             raise DownloadArtifactsError("Missing repository.")
 
@@ -111,7 +115,7 @@ class DownloadArtifacts:
         allow_not_found = allow_not_found or ActionIO.input("allow-not-found")
         self.allow_not_found = allow_not_found == "true"
 
-        self.is_debug = GitHubEnvironment().is_debug
+        self.is_debug = env.is_debug
 
         self.api = GitHubRESTApi(token)
 


### PR DESCRIPTION
**What**:

Default to the current repository for the input variable of the download artifact action.

**Why**:

Less required input arguments when used in the current repo.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
