### PR TITLE
Add: Allow to change group owner for downloaded artifacts

### DIFF
--- a/download-artifact/README.md
+++ b/download-artifact/README.md
@@ -56,6 +56,7 @@ jobs:
 | name            | Name of the artifact to be downloaded. If not set all artifacts will be downloaded.        | Optional                                          |
 | allow-not-found | Set to `true` to not fail if workflow or artifact can not be found.                        | Optional                                          |
 | user            | User ID for ownership of the downloaded artifacts.                                         | Optional                                          |
+| Group           | Group ID for ownership of the downloaded artifacts.                                        | Optional                                          |
 
 The name input parameter mimics the [actions/download-artifact@v3](https://github.com/actions/download-artifact/tree/v3#download-all-artifacts)
 behavior:

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -28,6 +28,9 @@ inputs:
   user:
     description: "User ID for ownership of the downloaded artifacts."
     required: false
+  group:
+    description: "Group ID for ownership of the downloaded artifacts."
+    required: false
 outputs:
   downloaded-artifacts:
     description: List of downloaded artifact names as JSON array string

--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -81,6 +81,7 @@ class DownloadArtifacts:
         path: Optional[str] = None,
         allow_not_found: Optional[str] = None,
         user: Union[str, int] = None,
+        group: Union[str, int] = None,
     ) -> None:
         env = GitHubEnvironment()
 
@@ -112,6 +113,13 @@ class DownloadArtifacts:
         try:
             # try to convert to int for a user id
             self.user = int(self.user)
+        except (ValueError, TypeError):
+            pass
+
+        self.group = group or ActionIO.input("group")
+        try:
+            # try to convert to int for a group id
+            self.group = int(self.group)
         except (ValueError, TypeError):
             pass
 
@@ -160,6 +168,7 @@ class DownloadArtifacts:
 
     def adjust_permissions(self, file_path: Path) -> None:
         try:
+            # should be made configurable via a input variable
             stat_result = os.stat(file_path)
             os.chmod(
                 file_path,
@@ -183,6 +192,15 @@ class DownloadArtifacts:
                 Console.warning(
                     f"Could not change owner of '{file_path}' to user "
                     f"'{self.user}'. Error was {e}."
+                )
+
+        if self.group:
+            try:
+                shutil.chown(file_path, None, self.group)
+            except (OSError, LookupError) as e:
+                Console.warning(
+                    f"Could not change owner of '{file_path}' to group "
+                    f"'{self.group}'. Error was {e}."
                 )
 
     def download_artifacts(


### PR DESCRIPTION
**What**:

Allow to change group owner for downloaded artifacts

**Why**:

To fix issues with permissions while using xz it must be possible to adjust the group owner of the downloaded artifacts.


**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
