### PR TITLE
Fix: Allow opening the URL from the workflow run console output

### DIFF
--- a/trigger-workflow/action/trigger.py
+++ b/trigger-workflow/action/trigger.py
@@ -179,9 +179,7 @@ class Trigger:
         if not run:
             raise TriggerError("Could not find workflow run.")
 
-        Console.log(
-            f"Found workflow run {run.get('id')} {run.get('html_url')}."
-        )
+        Console.log(f"Found workflow run {run.get('id')} {run.get('html_url')}")
 
         while True:
             if self.is_debug:


### PR DESCRIPTION
**What**:

Allow opening the URL from the workflow run console output

**Why**:

Remove dot at the end of the URL. Otherwise the dot is considered as part of the URL.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
