### PR TITLE
Change: Use GITHUB_BOT_TOKEN for testing trigger and download actions

### DIFF
--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Trigger Artifact Uploading
         uses: ./trigger-workflow
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
           ref: ${{ env.BRANCH }}
       - name: Download Artifact
         uses: ./download-artifact
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
           branch: ${{ env.BRANCH }}
@@ -41,14 +41,14 @@ jobs:
       - name: Download Artifacts
         uses: ./download-artifact
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
           branch: ${{ env.BRANCH }}
       - name: Ignore missing workflow
         uses: ./download-artifact
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "foo-bar.yml"
           branch: ${{ env.BRANCH }}
@@ -57,7 +57,7 @@ jobs:
       - name: Ignore missing artifact
         uses: ./download-artifact
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
           branch: ${{ env.BRANCH }}

--- a/.github/workflows/test-trigger-workflow.yml
+++ b/.github/workflows/test-trigger-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         id: test
         uses: ./trigger-workflow
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-trigger-workflow-long-running-workflow.yml"
           ref: ${{ env.REF }}
@@ -58,7 +58,7 @@ jobs:
       - name: Trigger Another Workflow
         uses: ./trigger-workflow
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-trigger-workflow-test-workflow.yml"
           ref: ${{ env.REF }}
@@ -84,7 +84,7 @@ jobs:
         continue-on-error: true
         uses: ./trigger-workflow
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-trigger-workflow-failing-workflow.yml"
           ref: ${{ env.REF }}


### PR DESCRIPTION
**What**:

Use GITHUB_BOT_TOKEN for testing trigger and download actions

**Why**:

The user of the github token might not have access permissions (like dependabot) for triggering, uploading and downloading artifacts for the tests. Therefore use a token with sufficient permissions.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] CHANGELOG.md entry
- [ ] Documentation
