### PR TITLE
mypy runs only in specified folder

### DIFF
--- a/mypy-python/action.yaml
+++ b/mypy-python/action.yaml
@@ -20,7 +20,7 @@ runs:
         version: ${{ inputs.version }}
     - run: echo "Running mypy"
       shell: bash
-    - run: poetry run mypy ${{ github.workspace }}
+    - run: poetry run mypy ${{ inputs.packages }}
       shell: bash
       name: Check with mypy
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
**What**:

Mypy no longer runs in base repo directionary, but rather in specified subfolder given in workflow variable "packages"

**Why**:

To fix a mypy error in which the same sourcefile is found in different module names

**How**:

Changed the folder in which mypy will run

**Checklist**:

- [ ] Tests
- [X ] Conventional Commit
- [ ] Documentation
