### PR TITLE
Change: Allow to specify workflow run events for to be downloaded artifacts

### DIFF
--- a/download-artifact/README.md
+++ b/download-artifact/README.md
@@ -50,13 +50,14 @@ jobs:
 | --------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------- |
 | token           | Token required to create the backport pull request                                         | Required                                          |
 | workflow        | Workflow to trigger. Either a workflow ID or file name, for example `ci.yml`.              | Required                                          |
+| workflow-events | Consider only workflow runs triggered by the specified events.                             | Default: `schedule, workflow_dispatch`            |
 | repository      | Repository of the workflow to trigger                                                      | Default: `GITHUB_REPOSITORY` (current repository) |
 | branch          | The git branch for the workflow.                                                           | Default: `main`                                   |
 | path            | Destination path for the to be downloaded artifact of parent directory if name is not set. | Default: `.` (Current directory)                  |
 | name            | Name of the artifact to be downloaded. If not set all artifacts will be downloaded.        | Optional                                          |
 | allow-not-found | Set to `true` to not fail if workflow or artifact can not be found.                        | Optional                                          |
 | user            | User ID for ownership of the downloaded artifacts.                                         | Optional                                          |
-| Group           | Group ID for ownership of the downloaded artifacts.                                        | Optional                                          |
+| group           | Group ID for ownership of the downloaded artifacts.                                        | Optional                                          |
 
 The name input parameter mimics the [actions/download-artifact@v3](https://github.com/actions/download-artifact/tree/v3#download-all-artifacts)
 behavior:

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -11,6 +11,10 @@ inputs:
   workflow:
     description: "Workflow to download the artifacts from. Either a workflow ID or file path. For example `ci.yml`."
     required: true
+  workflow-events:
+    description: "Consider only workflow runs triggered by the specified events. Default: schedule, workflow_dispatch"
+    default: "schedule, workflow_dispatch"
+    required: false
   branch:
     description: "The git branch for the workflow to download the artifacts from."
     required: true


### PR DESCRIPTION
**What**:

Allow to specify events for considered workflows runs to download artifacts.

DEVOPS-466

**Why**:

Before this change only workflow runs that have been triggered by schedules or workflow dispatch events were considered for downloading an artifact. With this change it is possible to configure the desired events via an input variable. If all events should be considered the workflow-events input variable can be set to and empty string.