### PR TITLE
Fix: Require latest pontos version for workflow run model parsing

### DIFF
--- a/download-artifact/poetry.lock
+++ b/download-artifact/poetry.lock
@@ -303,19 +303,19 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.6.0"
+version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
-test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pontos"
-version = "22.12.2"
+version = "22.12.3"
 description = "Common utilities and tools maintained by Greenbone Networks"
 category = "main"
 optional = false
@@ -457,7 +457,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6db6fcc541388069132a297d739f07a86bad0926edada7ec48c45fa9f78cda1d"
+content-hash = "26691b617729f69fb42ea4a33e6ea1aa51e0973951cf68c55b6e2308d814d2f8"
 
 [metadata.files]
 anyio = [
@@ -592,12 +592,12 @@ pathspec = [
     {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.6.0-py3-none-any.whl", hash = "sha256:1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca"},
-    {file = "platformdirs-2.6.0.tar.gz", hash = "sha256:b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e"},
+    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
+    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
 pontos = [
-    {file = "pontos-22.12.2-py3-none-any.whl", hash = "sha256:a11659dfaf0a1428f65e6f1c788a13a02e15683af3c22a1263bba5cfffa005be"},
-    {file = "pontos-22.12.2.tar.gz", hash = "sha256:2621e537df9f38f35c4c7696b826a6db25acc80675f2c0228a80c9b23160f05f"},
+    {file = "pontos-22.12.3-py3-none-any.whl", hash = "sha256:e2380fce6383dde16a5c98eb86537fdb60410b91d07671c230e21a2115b71d52"},
+    {file = "pontos-22.12.3.tar.gz", hash = "sha256:7756ab5187019115cd3040b3825cf74d6031c5350649c2cd48b022db16da3bfc"},
 ]
 pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},

--- a/download-artifact/pyproject.toml
+++ b/download-artifact/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pontos = ">=22.12.2"
+pontos = ">=22.12.3"
 
 [tool.poetry.dev-dependencies]
 autohooks-plugin-pylint = ">=22.8.0"

--- a/trigger-workflow/poetry.lock
+++ b/trigger-workflow/poetry.lock
@@ -303,19 +303,19 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.6.0"
+version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
-test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pontos"
-version = "22.12.2"
+version = "22.12.3"
 description = "Common utilities and tools maintained by Greenbone Networks"
 category = "main"
 optional = false
@@ -457,7 +457,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "c8fa601558b252747b0b62cbc6179d28b49628f17abeb7d2719a2da911b8c8b8"
+content-hash = "26691b617729f69fb42ea4a33e6ea1aa51e0973951cf68c55b6e2308d814d2f8"
 
 [metadata.files]
 anyio = [
@@ -592,12 +592,12 @@ pathspec = [
     {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.6.0-py3-none-any.whl", hash = "sha256:1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca"},
-    {file = "platformdirs-2.6.0.tar.gz", hash = "sha256:b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e"},
+    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
+    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
 pontos = [
-    {file = "pontos-22.12.2-py3-none-any.whl", hash = "sha256:a11659dfaf0a1428f65e6f1c788a13a02e15683af3c22a1263bba5cfffa005be"},
-    {file = "pontos-22.12.2.tar.gz", hash = "sha256:2621e537df9f38f35c4c7696b826a6db25acc80675f2c0228a80c9b23160f05f"},
+    {file = "pontos-22.12.3-py3-none-any.whl", hash = "sha256:e2380fce6383dde16a5c98eb86537fdb60410b91d07671c230e21a2115b71d52"},
+    {file = "pontos-22.12.3.tar.gz", hash = "sha256:7756ab5187019115cd3040b3825cf74d6031c5350649c2cd48b022db16da3bfc"},
 ]
 pygments = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},

--- a/trigger-workflow/pyproject.toml
+++ b/trigger-workflow/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pontos = ">=22.12.2"
+pontos = ">=22.12.3"
 
 [tool.poetry.dev-dependencies]
 autohooks-plugin-pylint = ">=22.8.0"


### PR DESCRIPTION
**What**:

Require latest pontos version for workflow run model parsing

**Why**:

Don't crash actions if a workflow run contains pull request data.