### PR TITLE
Fix: Don't set encoding if binary file is written

### DIFF
--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -234,7 +234,7 @@ class DownloadArtifacts:
                 end=" ",
             )
 
-            with temp_file.open("wb", encoding="utf8") as f:
+            with temp_file.open("wb") as f:
                 try:
                     async with self.api.artifacts.download(
                         self.repository, artifact.id


### PR DESCRIPTION
**What**:

Don't set encoding if binary file is written

**Why**:

Fix for
> ValueError: binary mode doesn't take an encoding argument