### PR TITLE
Fix: Try to fix loading the downloaded content as zip file

### DIFF
--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -253,6 +253,8 @@ class DownloadArtifacts:
                     f"'{destination_dir}'."
                 )
 
+                f.flush()
+
                 zipfile = ZipFile(temp_file)
                 for zipinfo in zipfile.infolist():
                     file_path = destination_dir / zipinfo.filename


### PR DESCRIPTION
**What**:

Ensure content is written to disk before reading it as a zip file.

**Why**:

Downloaded file isn't a zip file at the moment.