### PR TITLE
Fix release python action

### DIFF
--- a/release-python/action.yaml
+++ b/release-python/action.yaml
@@ -29,7 +29,7 @@ inputs:
     default: "patch"
   version:
     description: "Python version that should be installed"
-    default: 3.9
+    default: "3.10"
   ref:
     description: "Branch that should be released"
     default: ""

--- a/release-python/action.yaml
+++ b/release-python/action.yaml
@@ -107,9 +107,14 @@ runs:
       env:
         GITHUB_USER: ${{ inputs.github-user }}
         GITHUB_TOKEN: ${{ inputs.github-user-token }}
+    - name: Get release version
+      shell: bash
+      run: |
+        VERSION=$(poetry run pontos-version show)
+        echo "$VERSION" >> $GITHUB_ENV
     - name: Sign assets for released version
       run: |
-        poetry run pontos-release sign --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }}
+        poetry run pontos-release sign --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }} --release-version ${{ env.VERSION }}
       shell: bash
       env:
         GITHUB_USER: ${{ inputs.github-user }}


### PR DESCRIPTION
**What**:

Fix release python action by reverting daab64585a359182a0ce96b34d948204683c2a54

**Why**:

It's required to set a release version because after the actual release the version will be incremented to a `.dev` version