### PR TITLE
Try to fix CI error

### DIFF
--- a/release-python/action.yaml
+++ b/release-python/action.yaml
@@ -111,7 +111,7 @@ runs:
       shell: bash
       run: |
         VERSION=$(poetry run pontos-version show)
-        echo "$VERSION" >> $GITHUB_ENV
+        echo '"$VERSION"' >> $GITHUB_ENV
     - name: Sign assets for released version
       run: |
         poetry run pontos-release sign --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }} --release-version ${{ env.VERSION }}


### PR DESCRIPTION
## What

Try to fix CI error

## Why

Try to fix an error while putting the version into the environment. Error was:
> Errorr Unable to process file command 'env' successfully.
> Error: Invalid format 'x.y.z'.

## References

https://github.com/greenbone/greenbone-feed-sync/actions/runs/4023416442/jobs/6914261613


