### PR TITLE
Fix: Fix setting the VERSION GitHub environment variable

### DIFF
--- a/release-python/action.yaml
+++ b/release-python/action.yaml
@@ -104,7 +104,8 @@ runs:
       shell: bash
       run: |
         VERSION=$(poetry run pontos-version show)
-        echo '"$VERSION"' >> $GITHUB_ENV
+        echo "Releasing $VERSION"
+        echo '"VERSION=$VERSION"' >> $GITHUB_ENV
     - name: Create release
       run: |
         poetry run pontos-release release ${{ env.RELEASE_FLAGS }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -114,7 +114,8 @@ runs:
       run: |
         . .venv/bin/activate
         VERSION=$(pontos-version show)
-        echo '"$VERSION"' >> $GITHUB_ENV
+        echo "Releasing $VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Create release
       run: |
         . .venv/bin/activate


### PR DESCRIPTION


## What

Fix setting the VERSION GitHub environment variable

## Why

Setting a GitHub environment variable must use the "name=value" syntax.