### PR TITLE
Fix: Fix putting the VERSION into the GitHub environemnt for release-python action

### DIFF
--- a/release-python/action.yaml
+++ b/release-python/action.yaml
@@ -105,7 +105,7 @@ runs:
       run: |
         VERSION=$(poetry run pontos-version show)
         echo "Releasing $VERSION"
-        echo '"VERSION=$VERSION"' >> $GITHUB_ENV
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Create release
       run: |
         poetry run pontos-release release ${{ env.RELEASE_FLAGS }}


### PR DESCRIPTION

## What

Fix putting the VERSION into the GitHub environemnt for release-python action

## Why

Again the VERSION is not set correctly.

## References

https://github.com/greenbone/pontos/actions/runs/4072556604/jobs/7015447231

