### PR TITLE
Fix: Don't use github variables in action descriptions

### DIFF
--- a/backport-pull-request/action.yml
+++ b/backport-pull-request/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "GitHub Token for authentication"
     required: true
   username:
-    description: "GitHub user name to use for the backported commits. By default ${{ github.actor }} is used."
+    description: "GitHub user name to use for the backported commits. By default github.actor is used."
 
 runs:
   using: "docker"


### PR DESCRIPTION
## What

Don't use github variables in action descriptions

## Why

Don't use github variables in action descriptions

## References

https://github.com/greenbone/data-objects/actions/runs/4073269591/jobs/7016995658