### PR TITLE
Change: Extract checking version into an own action

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ SHA256 file or GPG signature generation
     file: ./foo/bar
 ```
 
+Check for consistent versioning in a project
+
+```yml
+- name: Check versioning
+  uses: greenbone/actions/check-version@v2
+```
+
 ## Support
 
 For any question on the usage of python-gvm please use the

--- a/check-version/action.yaml
+++ b/check-version/action.yaml
@@ -1,0 +1,25 @@
+name: "Python Package Linting"
+author: "Björn Ricks <bjoern.ricks@greenbone.net>"
+description: "An action to check version information via pontos"
+branding:
+  icon: "package"
+  color: "green"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python ${{ inputs.version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install pontos
+      run: |
+        python -m venv ${{ github.action_path }}/pontos-version-venv
+        source ${{ github.action_path }}/pontos-version-venv
+        python -m pip install pontos
+      shell: bash
+    - name: Check version information
+      run: |
+        source ${{ github.action_path }}/pontos-version-venv
+        python -m pontos.version verify current
+      shell: bash
+      working-directory: ${{ github.workspace }}

--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -1,4 +1,3 @@
-
 name: "Python Package Linting"
 author: "Björn Ricks <bjoern.ricks@greenbone.net>"
 description: "An action to lint Greenbone Python packages"
@@ -8,7 +7,7 @@ inputs:
     required: true
   version:
     description: "Python version that should be installed"
-    default: 3.9
+    default: "3.9"
 branding:
   icon: "package"
   color: "green"
@@ -30,10 +29,4 @@ runs:
     - run: poetry run pylint ${{ inputs.packages }}
       shell: bash
       name: Check with pylint
-      working-directory: ${{ github.workspace }}
-    - run: echo "Running pontos.version verify current"
-      shell: bash
-    - run: poetry run python -m pontos.version verify current
-      shell: bash
-      name: Check version information
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION

## What

Extract checking the version information of a project form the lint-python action into an own action.

## Why

Checking the version information isn't coupled to a linting run, is independent of Python projects and isn't required to run for each linted Python version. Therefore it is moved into an own separate action.

## References

DEVOPS-579

