### PR TITLE
Fix: Fix activating the python venv for check-version action

### DIFF
--- a/check-version/action.yaml
+++ b/check-version/action.yaml
@@ -14,12 +14,12 @@ runs:
     - name: Install pontos
       run: |
         python -m venv ${{ github.action_path }}/pontos-version-venv
-        source ${{ github.action_path }}/pontos-version-venv
+        source ${{ github.action_path }}/pontos-version-venv/bin/activate
         python -m pip install pontos
       shell: bash
     - name: Check version information
       run: |
-        source ${{ github.action_path }}/pontos-version-venv
+        source ${{ github.action_path }}/pontos-version-venv/bin/activate
         python -m pontos.version verify current
       shell: bash
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## What

Fix activating the python venv for check-version action

## Why

It's broken

## References
DEVOPS-579


