### PR TITLE
Fix: Always disable admin bypassing

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -99,6 +99,7 @@ runs:
         GITHUB_USER: ${{ inputs.github-user }}
         GITHUB_TOKEN: ${{ inputs.github-user-token }}
     - name: Disable bypassing protection on ${{ inputs.ref}} branch for admin users
+      if: always()
       uses: greenbone/actions/admin-bypass@v2
       with:
         allow: "false"


### PR DESCRIPTION
## What

Fix: Always disable admin bypassing #394
Even if the worfklow fails.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

when workflow fails is should be disabled anyways



