### PR TITLE
Add: release-version input to release action

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Release a project in C, GoLang, JavaScript or Python
     gpg-key: boo
     gpg-passphrase: foo
     gpg-fingerprint: baz
-    strategy: calendar
+    release-type: calendar
     ref: main
 ```
 

--- a/release/README.md
+++ b/release/README.md
@@ -1,14 +1,20 @@
 # Release action
 
-You can use the release action to release a project within a GitHub Action workfl.
+You can use the release action to release a project within a GitHub Action workflow.
+
+## Supported Programming Languages
+
 Currently supported programming languages:
-* C
+* C/C++ (CMake)
 * GoLang
 * JavaScript
 * Python
 * TypeScript
 
-Currently this action can create `major`, `minor`, `patch` and `pre-releases`. Additionally you can use `calendar` versioning.
+## Supported Release types
+
+Currently this action can create different types of releases.
+Supported with the `release-type` argument are `major`, `minor`, `patch` and different type of `pre-releases`. Additionally you can also use `calendar` versioning.
 
 | Type              | Old version  | New version  |
 |-------------------|--------------|--------------|
@@ -24,10 +30,32 @@ Currently this action can create `major`, `minor`, `patch` and `pre-releases`. A
 | calendar          |     `20.5.1` |     `23.2.0` |
 | calendar          |     `23.2.1` |     `23.2.2` |
 
-## Example
+You can alternatively set an explicit `release-version`. It will overwrite the `release-type` argument.
+
+**NOTE:** The release will only be successful, if the release version has a valid schema.
+
+## Input arguments
+
+| Argument             | Description                                                                                                                     | Required? | Default               |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------|-----------|-----------------------|
+| conventional-commits | Deprecated                                                                                                                      | No        | None                  |
+| github-user          | Github user name on behalf of whom the actions will be executed.                                                                | Yes       | None                  |
+| github-user-mail     | Mail address for the given github user.                                                                                         | Yes       | None                  |
+| github-user-token    | Token with write rights required to create the release.                                                                         | Yes       | None                  |
+| gpg-fingerprint      | GPG fingerprint, represented as a string. Required for signing assets of the release.                                           | No        | None                  |
+| gpg-key              | GPG key, represented as a string. Required for signing assets of the release.                                                   | No        | None                  |
+| gpg-passphrase       | GPG passphrase, represented as a string. Required for signing assets of the release.                                            | No        | None                  |
+| strategy             | Deprecated by `release-type`.                                                                                                   | No        | None                  |
+| python-version       | Python version used to create the release. (Only important for python projects)                                                 | No        | `"3.10"`              |
+| ref                  | This branch's/tag's HEAD will be candidate of the next release.                                                                 | No        | `""` (default branch) |
+| release-type         | What type of release should be executed? Supported: `alpha`, `beta`, `calendar`, `major`, `minor`, `patch`, `release-candidate` | No        | `patch`               |
+| release-version      | Set an explicit version, that should be released.                                                                               | No        | None                  |
+
+
+## Examples
 
 ```yml
-- name: Run release actions
+- name: Run release actions with release type
   uses: greenbone/actions/release@v2
   with:
     github-user: ${{ secrets.FOO_BAR }}
@@ -36,6 +64,19 @@ Currently this action can create `major`, `minor`, `patch` and `pre-releases`. A
     gpg-key: boo
     gpg-passphrase: foo
     gpg-fingerprint: baz
-    strategy: calendar
+    release-type: minor
+```
+
+```yml
+- name: Run release actions with release version
+  uses: greenbone/actions/release@v2
+  with:
+    github-user: ${{ secrets.FOO_BAR }}
+    github-user-mail: foo@bar.baz
+    github-user-token: bar
+    gpg-key: boo
+    gpg-passphrase: foo
+    gpg-fingerprint: baz
+    release-version: 2.0.0a1
     ref: main
 ```

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -25,7 +25,7 @@ inputs:
   strategy:
     description: "Deprecated by release-type."
   python-version:
-    description: "Python version used for release."
+    description: "Python version used  to create the release. (Only important for python projects)"
     default: "3.10"
   ref:
     description: "This branch's/tag's HEAD will be candidate of the next release. Default: default branch"

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -16,28 +16,27 @@ inputs:
   github-user-token:
     description: "Token with write rights required to create the release."
     required: true
-  gpg-key:
-    description: "GPG key, represented as a string. Required for signing assets of the release."
-    required: false
   gpg-fingerprint:
     description: "GPG fingerprint, represented as a string. Required for signing assets of the release."
-    required: false
+  gpg-key:
+    description: "GPG key, represented as a string. Required for signing assets of the release."
   gpg-passphrase:
     description: "GPG passphrase, represented as a string. Required for signing assets of the release."
-    required: false
   strategy:
     description: "Deprecated by release-type."
+  python-version:
+    description: "Python version used for release."
+    default: "3.10"
+  ref:
+    description: "This branch's/tag's HEAD will be candidate of the next release. Default: default branch"
+    default: ""
   release-type:
     description: |
       "What type of release should be executed?"
       "Supported: ['alpha', 'beta', 'calendar', 'major', 'minor', 'patch',  'release-candidate']; Default: patch"
     default: "patch"
-  python-version:
-    description: "Python version that should be installed"
-    default: "3.10"
-  ref:
-    description: "This branches HEAD will be candidate of the next release"
-    default: ""
+  release-version:
+    description: "Set an explicit version, that should be released."
 
 branding:
   icon: "package"
@@ -46,6 +45,7 @@ branding:
 runs:
   using: "composite"
   steps:
+      # Setup
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 #for conventional commits
@@ -63,12 +63,21 @@ runs:
         python -m pip install --upgrade pontos
       shell: bash
     - name: Set git name, mail and origin
+      uses: greenbone/actions/set-github-user@v2
+      with:
+        name: ${{ inputs.github-user }}
+        mail: ${{ inputs.github-user-mail }}
+        token: ${{ inputs.github-user-token }}
+    - name: Import gpg key from secrets
       run: |
-        git config --global user.name "${{ inputs.github-user }}"
-        git config --global user.email "${{ inputs.github-user-mail }}"
-        git remote set-url origin https://${{ inputs.github-user-token }}@github.com/${{ github.repository }}
+        echo -e "${{ inputs.gpg-key }}" >> tmp.file
+        gpg --pinentry-mode loopback --passphrase ${{ inputs.gpg-passphrase }} --import tmp.file
+        rm tmp.file
       shell: bash
-    - name: Parse inputs
+      if: ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
+
+      # Input parsing
+    - name: Parse release-type
       run: |
         case ${{ inputs.release-type }} in
           alpha | beta | calendar | major | minor | patch | release-candidate)
@@ -84,12 +93,21 @@ runs:
         fi
         echo "ARGS=${ARGS}" >> $GITHUB_ENV
       shell: bash
+    - name: Parse release-version if set (overwrite release-type)
+      if: ${{ inputs.release-version }}
+      run: |
+        ARGS="--release-version ${{ inputs.release-version }}"
+      shell: bash
+
+      # Enable admin bypass
     - name: Allow admin users bypassing protection on ${{ inputs.ref}} branch
       uses: greenbone/actions/admin-bypass@v2
       with:
         allow: "true"
         github-token: ${{ inputs.github-user-token }}
         branch: ${{ inputs.ref}}
+
+      # Create release
     - name: Create automatic release
       run: |
         source ${{ github.action_path }}/pontos-release-venv/bin/activate
@@ -98,6 +116,8 @@ runs:
       env:
         GITHUB_USER: ${{ inputs.github-user }}
         GITHUB_TOKEN: ${{ inputs.github-user-token }}
+
+      # Disable admin bypass
     - name: Disable bypassing protection on ${{ inputs.ref}} branch for admin users
       if: always()
       uses: greenbone/actions/admin-bypass@v2
@@ -105,16 +125,11 @@ runs:
         allow: "false"
         github-token: ${{ inputs.github-user-token }}
         branch: ${{ inputs.ref}}
-    - name: Import gpg key from secrets
-      run: |
-        echo -e "${{ inputs.gpg-key }}" >> tmp.file
-        gpg --pinentry-mode loopback --passphrase ${{ inputs.gpg-passphrase }} --import tmp.file
-        rm tmp.file
-      shell: bash
-      if: ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
+
+      # Signing
     - name: Sign assets for released version
       run: |
-        echo "Signing assets for ${{env.VERSION}}"
+        echo "Signing release assets"
         source ${{ github.action_path }}/pontos-release-venv/bin/activate
         pontos-release sign --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }}
       shell: bash

--- a/set-github-user/action.yaml
+++ b/set-github-user/action.yaml
@@ -1,0 +1,30 @@
+name: "Action to set up the user for the workflow"
+author: "Jaspar Stach <jaspar.stach@greenbone.net>"
+description: |
+  "An action that sets up the machines github user and email and "
+  "activates the users tokens permissions to execute git commands."
+
+# Never look up these commands again. :)
+
+inputs:
+  user:
+    description: "GitHub user name on behalf of whom the actions will be executed."
+    required: true
+  mail:
+    description: "Mail address for the given GitHub user."
+    required: true
+  token:
+    description: "The GitHub user's token (PAT)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - run: echo "Setting up GitHub user and git permissions"
+      shell: bash
+    - name: Set git name, mail and origin
+      run: |
+        git config --global user.name "${{ inputs.github-user }}"
+        git config --global user.email "${{ inputs.github-user-mail }}"
+        git remote set-url origin https://${{ inputs.github-user-token }}@github.com/${{ github.repository }}
+      shell: bash


### PR DESCRIPTION
## What

* Add `release-action` input argument to release action
  * If set, it will overwrite the `release-type` argument and the given version will be released, if it is valid (e.g. SemVer or PEP440)
* I have moved the github user setup into a separat action, since these are steps I always need to look up at some weird places (guessing in which action I may have used it)
* Improved readability and refactored the action

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* We need to be able to set the version explicit in some situations.

<!-- Describe why are these changes necessary? -->

## References

DEVOPS-599

