### PR TITLE
Add: input arguments to pass to the workflow, in trigger-workflow action

### DIFF
--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
     default: "main"
   inputs:
-    description: "Inputs to pass to the workflow, must be a JSON string. All values must be strings (even if used as boolean or number)."
+    description: "Inputs to pass to the workflow, must be a JSON string and single quotation marks are not allowed. All values must be strings (even if used as boolean or number)."
     required: false
     default: "{}"
   wait-for-completion-timeout:

--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -44,4 +44,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        poetry run trigger-workflow --token ${{ inputs.token }} --repository ${{ inputs.repository }} --workflow ${{ inputs.workflow }} --ref ${{ inputs.ref }} --timeout ${{ inputs.wait-for-completion-timeout }} --interval ${{ inputs.wait-for-completion-interval }}
+        cmd='--token ${{ inputs.token }} --repository ${{ inputs.repository }} --workflow ${{ inputs.workflow }} --ref ${{ inputs.ref }} --timeout ${{ inputs.wait-for-completion-timeout }} --interval ${{ inputs.wait-for-completion-interval }}'
+        if [ "${{ inputs.token }}" ]; then
+          cmd+=" --inputs '${{ inputs.inputs }}'"
+        poetry run trigger-workflow  $cmd

--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -18,6 +18,7 @@ inputs:
   inputs:
     description: "Inputs to pass to the workflow, must be a JSON string. All values must be strings (even if used as boolean or number)."
     required: false
+    default: "{}"
   wait-for-completion-timeout:
     description: "Maximum amount of time in seconds to wait to for workflow to finish. Set to empty string or false to not wait for the workflow."
     required: false
@@ -44,9 +45,11 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        cmd='--token ${{ inputs.token }} --repository ${{ inputs.repository }} --workflow ${{ inputs.workflow }} --ref ${{ inputs.ref }} --timeout ${{ inputs.wait-for-completion-timeout }} --interval ${{ inputs.wait-for-completion-interval }}'
-        if [ "${{ inputs.inputs }}" ]; then
-          poetry run trigger-workflow $cmd --inputs '${{ inputs.inputs }}'
-        else
-          poetry run trigger-workflow $cmd
-        fi
+          poetry run trigger-workflow \
+            --token ${{ inputs.token }} \
+            --repository ${{ inputs.repository }} \
+            --workflow ${{ inputs.workflow }} \
+            --ref ${{ inputs.ref }} \
+            --timeout ${{ inputs.wait-for-completion-timeout }} \
+            --interval ${{ inputs.wait-for-completion-interval }} \
+            --inputs '${{ inputs.inputs }}'

--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -45,6 +45,8 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         cmd='--token ${{ inputs.token }} --repository ${{ inputs.repository }} --workflow ${{ inputs.workflow }} --ref ${{ inputs.ref }} --timeout ${{ inputs.wait-for-completion-timeout }} --interval ${{ inputs.wait-for-completion-interval }}'
-        if [ "${{ inputs.token }}" ]; then
-          cmd+=" --inputs '${{ inputs.inputs }}'"
-        poetry run trigger-workflow  $cmd
+        if [ "${{ inputs.inputs }}" ]; then
+          poetry run trigger-workflow $cmd --inputs '${{ inputs.inputs }}'
+        else
+          poetry run trigger-workflow $cmd
+        fi


### PR DESCRIPTION
## What
Enable input arguments to pass to the workflow, in trigger-workflow action.

## Why
We need them.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-614
<!-- Add identifier for issue tickets, links to other PRs, etc. -->


