### PR TITLE
Change: Enable Python dependencies caching for poetry by default

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -11,6 +11,9 @@ inputs:
     description: "Do not install the project itself, only the dependencies"
   without-dev:
     description: "Do not install the development dependencies"
+  cache:
+    description: "Cache the poetry dependencies by default. Empty string to disable the cache."
+    default: "poetry"
 branding:
   icon: "package"
   color: "green"
@@ -22,6 +25,7 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.version }}
+        cache: ${{ inputs.cache }}
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip

--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -30,6 +30,7 @@ runs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade poetry
+        echo "Installed:\n* $(poetry --version)\n* $(pip --version)"
       shell: bash
     - name: Parse inputs
       run: |


### PR DESCRIPTION
## What

Cache dependencies when using the poetry action by default.

## Why

Allow for faster setups by default.

## References

DEVOPS-618



