### PR TITLE
Change: Allow to install a specific version of poetry

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -14,6 +14,8 @@ inputs:
   cache:
     description: "Cache the poetry dependencies by default. Empty string to disable the cache."
     default: "poetry"
+  poetry-version:
+    description: "Use a specific poetry version. By default the latest release is used."
 branding:
   icon: "package"
   color: "green"
@@ -26,10 +28,17 @@ runs:
       with:
         python-version: ${{ inputs.version }}
         cache: ${{ inputs.cache }}
-    - name: Install poetry
+    - name: Install pip
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade poetry
+      shell: bash
+    - name: Install poetry ${{ inputs.poetry-version }}
+      run: |
+        if [[ -n "${{ inputs.poetry-version }}" ]]; then
+          python -m pip install --upgrade poetry==${{ inputs.poetry-version }}
+        else
+          python -m pip install --upgrade poetry
+        fi
         echo "Installed:\n* $(poetry --version)\n* $(pip --version)"
       shell: bash
     - name: Parse inputs


### PR DESCRIPTION
## What

Allow to install a specific version of poetry

## Why

The newest poetry release may have issues (like https://github.com/pradyunsg/furo/discussions/639 as seen for example at https://github.com/greenbone/pontos/actions/runs/4477585184/jobs/7869294603) therefore we might need to install an older release.


