### PR TITLE
Remove cache

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -11,9 +11,6 @@ inputs:
     description: "Do not install the project itself, only the dependencies"
   without-dev:
     description: "Do not install the development dependencies"
-  cache:
-    description: "Cache the poetry dependencies by default. Empty string to disable the cache."
-    default: "poetry"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
 branding:
@@ -27,7 +24,6 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.version }}
-        cache: ${{ inputs.cache }}
     - name: Install pip
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## What
Remove the caching and revert #441 

## Why

The caching of the setup-python action doesn't work as expected and can't be used for our action.

Requires #442 to be merged.


