### PR TITLE
Change: Try to fix poetry caching with setup-python

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -23,6 +23,16 @@ branding:
 runs:
   using: "composite"
   steps:
+    - name: Install poetry ${{ inputs.poetry-version }}
+      # poetry needs to be installed before using setup-python with poetry cache
+      if: ${{ inputs.cache == 'poetry' }}
+      run: |
+        if [[ -n "${{ inputs.poetry-version }}" ]]; then
+          python -m pip install --upgrade poetry==${{ inputs.poetry-version }}
+        else
+          python -m pip install --upgrade poetry
+        fi
+      shell: bash
     - name: Set up Python ${{ inputs.version }}
       uses: actions/setup-python@v4
       with:
@@ -33,13 +43,19 @@ runs:
         python -m pip install --upgrade pip
       shell: bash
     - name: Install poetry ${{ inputs.poetry-version }}
+      # ensure that poetry is installed in the current set up python environment
+      # if poetry cache isn't used
+      if: ${{ inputs.cache != 'poetry' }}
       run: |
         if [[ -n "${{ inputs.poetry-version }}" ]]; then
           python -m pip install --upgrade poetry==${{ inputs.poetry-version }}
         else
           python -m pip install --upgrade poetry
         fi
-        echo "Installed:\n* $(poetry --version)\n* $(pip --version)"
+      shell: bash
+    - name: List installed
+      run: |
+        echo "Installed:\n* $(which poetry) $(poetry --version)\n* $(pip --version)"
       shell: bash
     - name: Parse inputs
       run: |


### PR DESCRIPTION
## What

Try to fix poetry caching with setup-python

## Why

It seems that setup-python handles changing the current python version according to the desired setup (https://github.com/actions/setup-python/blob/main/src/cache-distributions/poetry-cache.ts#L61-L62). Therefore install poetry into the system python before setup-python is called if poetry caching is used.


## References

DEVOPS-618


