### PR TITLE
Change: Make poetry caching opt-in instead of opt-out

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -12,8 +12,7 @@ inputs:
   without-dev:
     description: "Do not install the development dependencies"
   cache:
-    description: "Cache the poetry dependencies by default. Empty string to disable the cache."
-    default: "poetry"
+    description: "Cache dependencies by setting it to poetry. Leave unset or set to empty string to disable the cache."
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
   poetry-version:


### PR DESCRIPTION
## What

Make poetry caching opt-in instead of opt-out

## Why

It seems enabling poetry caching creates a lot of issues. Therefore make it optional and opt-in.

## References

DEVOPS-618
