### PR TITLE
This action scans your pull requests for dependency changes

### DIFF
--- a/dependency-review/README.md
+++ b/dependency-review/README.md
@@ -1,0 +1,7 @@
+dependency-review-action
+
+This action scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid licenses are being introduced. The action is supported by an API endpoint that diffs the dependencies between any two revisions on your default branch.
+
+The action is available for all public repositories, as well as private repositories that have GitHub Advanced Security licensed.
+
+More information availabe in [dependency-review-action](https://github.com/actions/dependency-review-action)

--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -1,0 +1,19 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: high
+          vulnerability-check: true
+          license-check: true
+          allow-licenses: AGPL-3.0-or-later, GPL-3.0-or-later, LGPL-2.1, EPL-2.0, Python-2.0, GPL-2.0-or-later, GPL-2.0-only, MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, CC-BY-SA-4.0


### PR DESCRIPTION
## What

This action scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid licenses are being introduced.

## Why

This is a part of the GitHub Advanced Security to improve our Security in Github.

## References

Related to Jira [DEVOPS-624](https://jira.greenbone.net/browse/DEVOPS-624)
More info [dependency-review-action](https://github.com/actions/dependency-review-action)