### PR TITLE
Add more license due to error

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -14,4 +14,4 @@ runs:
         fail-on-severity: high
         vulnerability-check: true
         license-check: true
-        allow-licenses: AGPL-3.0-or-later, GPL-3.0-or-later, LGPL-2.1, EPL-2.0, Python-2.0, GPL-2.0-or-later, GPL-2.0-only, MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, CC-BY-SA-4.0
+        allow-licenses: AGPL-3.0-or-later, GPL-3.0-or-later, LGPL-2.1, EPL-2.0, Python-2.0, GPL-2.0-or-later, GPL-2.0-only, MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause, CC-BY-SA-4.0, BSD-2-Clause AND BSD-3-Clause


### PR DESCRIPTION
## What

Add one more allowed license BSD-2-Clause AND BSD-3-Clause 

## Why

Due to error: dependency review detected incompatible licenses 

## References
[DEVOPS-624](https://jira.greenbone.net/browse/DEVOPS-624)
[License in Software Products](https://confluence.greenbone.net/display/IQMS/License+in+Software+Products)
[dependency-review](https://github.com/actions/dependency-review-action)



