### PR TITLE
Fix: Make repository argument for download-artifact optional

### DIFF
--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -81,7 +81,7 @@ def temp_directory() -> Generator[Path, None, None]:
 def parse_arguments() -> Namespace:
     parser = ArgumentParser()
     parser.add_argument("--token", required=True)
-    parser.add_argument("--repository")
+    parser.add_argument("--repository", nargs="?")
     parser.add_argument("--workflow", required=True)
     parser.add_argument("--workflow-events", nargs="?")
     parser.add_argument("--branch", required=True)


### PR DESCRIPTION
## What

Make repository argument for download-artifact optional

## Why

When using actions and action arguments optional python arguments must allow `--foo` with no additional value.

## References

https://github.com/greenbone/vulnerability-tests/actions/runs/4614487072/jobs/8159510983

