### PR TITLE
Fix: Don't run apt-get install on runners

### DIFF
--- a/admin-bypass/action.yaml
+++ b/admin-bypass/action.yaml
@@ -29,7 +29,6 @@ runs:
         python-version: 3.9
     - name: Install pontos
       run: |
-        apt-get --assume-yes install python3-venv wget
         python3 -m venv .venv
         . .venv/bin/activate
         python -m pip install --upgrade pip


### PR DESCRIPTION
## What

Don't run apt-get install on runners

## Why

It seems that this command fails and breaks the action. Also it should not be necessary because wget is already installed and venv should be available after setup-python is run.

## References

https://github.com/greenbone/troubadix/actions/runs/4677351555/jobs/8287964525

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


