### PR TITLE
Fix: Don't install codecov python package

### DIFF
--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -33,10 +33,6 @@ runs:
         poetry-version: ${{ inputs.poetry-version }}
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
-    - run: poetry run python -m pip install codecov
-      shell: bash
-      name: Install codecov-python
-      working-directory: ${{ github.workspace }}
     - run: poetry run coverage run ${{ inputs.test-command }}
       shell: bash
       name: Run unit tests with coverage


### PR DESCRIPTION
## What

Don't install codecov python package

## Why

The package is deprecated and removed from PyPI yesterday. Also installing it seems to be a leftover in our action.

## References

https://about.codecov.io/blog/message-regarding-the-pypi-package/


