### PR TITLE
Fix: Remove trailing comma in allowed licenses list

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -30,4 +30,4 @@ runs:
           MPL-2.0,
           CC-BY-SA-4.0,
           BSD-2-Clause AND BSD-3-Clause,
-          (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT),
+          (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT)


### PR DESCRIPTION
## What

Remove trailing comma in allowed licenses list

## Why

Fix checking for licenses

## References

https://github.com/greenbone/actions/actions/runs/4687322904/jobs/8307120628


