### PR TITLE
Fix: Allow to run conventional commits check in workspace

### DIFF
--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -29,10 +29,11 @@ runs:
         cache-dependency-path: ${{ github.action_path }}/poetry.lock
     - name: Run conventional commits
       shell: bash
-      working-directory: ${{ github.workspace }}
+      working-directory: ${{ github.action_path }}
       run: |
         poetry run conventional-commits \
           --token ${{ inputs.token }} \
           --base-ref ${{ github.base_ref }} \
           --event-path ${{ github.event_path }} \
-          --repository ${{ github.repository }}
+          --repository ${{ github.repository }} \
+          --working-directory ${{ github.workspace }}


### PR DESCRIPTION

## What

Allow to run conventional commits check in workspace

## Why

The action itself must be run from the action path as working directory to use the correct virtual environment. To check the desired project for conventional commits a working directory argument is added.


## References

DEVOPS-602


