### PR TITLE
Fix: Use base ref with remote name

### DIFF
--- a/conventional-commits/action/commits.py
+++ b/conventional-commits/action/commits.py
@@ -79,7 +79,7 @@ class Commits:
             project=project,
             config=config_file if config_file.exists() else None,
         )
-        commit_dict = builder.get_commits(self.base_ref)
+        commit_dict = builder.get_commits(f"origin/{self.base_ref}")
 
         comment_lines = [
             CONVENTIONAL_COMMIT_REPORT_LINE,


### PR DESCRIPTION
## What

Use base ref with remote name
## Why

For creating the git log of the changes in a pull request the git ref must be used with the remote name because it isn't checked out.


## References
DEVOPS-602
