### PR TITLE
Change: Allow to disable installing dependencies via poetry

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         uses: ./poetry
+        with:
+          install-dependencies: "false"
       - run: poetry --version
 
   test-coverage:
@@ -28,7 +30,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         uses: ./coverage-python
-        continue-on-error: true
+        with:
+          install-dependencies: "false"
       - run: poetry
 
   test-linting:
@@ -39,5 +42,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         uses: ./lint-python
-        continue-on-error: true
+        with:
+          install-dependencies: "false"
       - run: poetry

--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -21,6 +21,9 @@ inputs:
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"
+  install-dependencies:
+    description: "Install project dependencies. Default is 'true'. Set to an other string then 'true' to not install the dependencies."
+    default: "true"
 
 branding:
   icon: "package"
@@ -37,6 +40,7 @@ runs:
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
         cache-poetry-installation: ${{ inputs.cache-poetry-installation }}
+        install-dependencies: ${{ inputs.install-dependencies }}
     - run: poetry run coverage run ${{ inputs.test-command }}
       shell: bash
       name: Run unit tests with coverage

--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -18,6 +18,9 @@ inputs:
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"
+  install-dependencies:
+    description: "Install project dependencies. Default is 'true'. Set to an other string then 'true' to not install the dependencies."
+    default: "true"
 
 branding:
   icon: "package"
@@ -34,6 +37,7 @@ runs:
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
         cache-poetry-installation: ${{ inputs.cache-poetry-installation }}
+        install-dependencies: ${{ inputs.install-dependencies }}
     - run: echo "Running black"
       shell: bash
     - run: poetry run black --check --diff ${{ inputs.packages }}

--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -7,6 +7,9 @@ inputs:
     default: "3.9"
   working-directory:
     description: "A working directory where to run poetry install"
+  install-dependencies:
+    description: "Install project dependencies. Default is 'true'. Set to an other string then 'true' to not install the dependencies."
+    default: "true"
   no-root:
     description: "Do not install the project itself, only the dependencies"
   without-dev:
@@ -87,6 +90,7 @@ runs:
         echo " * $(pip --version)"
       shell: bash
     - name: Parse inputs
+      if: ${{ inputs.install-dependencies == 'true' }}
       run: |
         if [[ -n "${{ inputs.no-root }}" ]]; then
           ARGS="--no-root"
@@ -97,6 +101,7 @@ runs:
         echo "ARGS=${ARGS}" >> $GITHUB_ENV
       shell: bash
     - name: Install dependencies
+      if: ${{ inputs.install-dependencies == 'true' }}
       run: poetry install ${{ env.ARGS }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION


## What
Allow to disable installing dependencies via poetry
## Why

Sometime we just want to have poetry available and not to install the project dependencies. Therefore make the installation step optional.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


