### PR TITLE
Added action SPDX to dependency graph

### DIFF
--- a/sbom-upload/README.md
+++ b/sbom-upload/README.md
@@ -1,0 +1,25 @@
+SPDX to Dependency Graph Action
+
+This action makes it easy to upload an SPDX 2.2 formatted SBOM to GitHub's dependency submission API. This lets you quickly receive Dependabot alerts for package manifests which GitHub doesn't directly support like pnpm or Paket by using existing off-the-shelf SBOM generators.
+
+More information availabe in [spdx-dependency-submission](https://github.com/marketplace/actions/spdx-dependency-submission-action)
+
+
+#### Example using as a Workflow
+
+```yaml
+name: SBOM upload
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+jobs:
+    SBOM-upload:
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write
+        contents: write
+    steps:
+      - name: 'SBOM upload'
+        uses: greenbone/actions/sbom-upload@v2
+```

--- a/sbom-upload/action.yml
+++ b/sbom-upload/action.yml
@@ -11,7 +11,7 @@ runs:
       run: |
         curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
         chmod +x $RUNNER_TEMP/sbom-tool
-        $RUNNER_TEMP/sbom-tool generate -b . -bc . -pn ${{ github.repository }} -pv 1.0.0 -ps OwnerName -nsb https://sbom.mycompany.com -V Verbose
+        $RUNNER_TEMP/sbom-tool generate -b . -bc . -pn ${{ github.repository }} -pv 1.0.0 -ps Greenbone AG -nsb https://greenbone.net -V Verbose
     - uses: actions/upload-artifact@v3
       with:
         name: sbom

--- a/sbom-upload/action.yml
+++ b/sbom-upload/action.yml
@@ -1,0 +1,22 @@
+name: "SBOM upload"
+description: "Receive Dependabot alerts for package manifests"
+branding:
+  icon: "box"
+  color: "blue"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: Generate SBOM
+      run: |
+        curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
+        chmod +x $RUNNER_TEMP/sbom-tool
+        $RUNNER_TEMP/sbom-tool generate -b . -bc . -pn ${{ github.repository }} -pv 1.0.0 -ps OwnerName -nsb https://sbom.mycompany.com -V Verbose
+    - uses: actions/upload-artifact@v3
+      with:
+        name: sbom
+        path: _manifest/spdx_2.2
+    - name: SBOM upload
+      uses: advanced-security/spdx-dependency-submission-action@v0.0.1
+      with:
+        filePath: "_manifest/spdx_2.2/"


### PR DESCRIPTION
## What

Implementing SPDX to Dependency Graph Action.

## Why

Improve security posture via the Github Enterprise Advanced Security action to makes it easy to upload an SPDX 2.2 formatted SBOM to GitHub's dependency submission API.
This lets you quickly receive Dependabot alerts for package manifests which GitHub doesn't directly support like pnpm or Paket by using existing off-the-shelf SBOM generators.

## References

Related to Jira [DEVOPS-622](https://jira.greenbone.net/browse/DEVOPS-622)
More info [spdx-dependency-submission-action](https://github.com/marketplace/actions/spdx-dependency-submission-action)


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tested in pipeline experiments
