### PR TITLE
Added license MIT/Apache-2.0

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -30,4 +30,5 @@ runs:
           MPL-2.0,
           CC-BY-SA-4.0,
           BSD-2-Clause AND BSD-3-Clause,
+          MIT/Apache-2.0,
           (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT)


### PR DESCRIPTION
## What

Added license MIT/Apache-2.0 to the 

## Why

License naming scheme is not unified so this variant must be added otherwise an error is raised.