### PR TITLE
Fix: Fix generating hashsums for files with spaces in their name

### DIFF
--- a/hashsums/action.yaml
+++ b/hashsums/action.yaml
@@ -1,5 +1,6 @@
 name: "Generate a hashsums file"
 description: "Generate a file containing hashsums for all files of a directory"
+
 inputs:
   hash:
     description: "Which hashsum program to use. Default is sha256sum."
@@ -9,9 +10,11 @@ inputs:
     required: true
   filename:
     description: "Name of the generated hashsums file. Default is sha256sums."
+
 branding:
   icon: "package"
   color: "green"
+
 runs:
   using: "composite"
   steps:

--- a/hashsums/hashsums.sh
+++ b/hashsums/hashsums.sh
@@ -10,7 +10,7 @@ build_hash_for_files() {
         if [ -d "$f" ]; then
             build_hash_for_files "$1" "$f" "$3" || return $?
         elif [ -e "$f" ]; then
-            $1 $f >> $3 || return $?
+            $1 "$f" >> "$3" || return $?
         else
             continue
         fi


### PR DESCRIPTION
## What

Fix generating hashsums for files with spaces in their name

## Why

Always quote variables when generating the hashsum to support spaces in the current file name.

## References

DEVOPS-625