### PR TITLE
Change: Always run testing workflows

### DIFF
--- a/.github/workflows/test-hashsums.yml
+++ b/.github/workflows/test-hashsums.yml
@@ -3,11 +3,10 @@ name: Test Python Actions
 on:
   push:
     tags: ["*"]
-    branches: [main]
-    paths: ["hashsums/**", ".github/workflows/test-hashsums.yml"]
+    branches:
+      - main
+      - "v*"
   pull_request:
-    branches: [main]
-    paths: ["hashsums/**", ".github/workflows/test-hashsums.yml"]
 
 jobs:
   test-creating-sha256sums-file:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -3,11 +3,10 @@ name: Test Python Actions
 on:
   push:
     tags: [ "*" ]
-    branches: [ main ]
-    paths: [ "poetry/**","poetry/**","coverage-python/**","lint-python/**", ".github/workflows/test-python.yml" ]
+    branches:
+      - main
+      - "v*"
   pull_request:
-    branches: [ main ]
-    paths: [ "poetry/**","poetry/**","coverage-python/**","lint-python/**", ".github/workflows/test-python.yml" ]
 
 jobs:
   install-poetry:

--- a/.github/workflows/test-signature.yml
+++ b/.github/workflows/test-signature.yml
@@ -3,11 +3,10 @@ name: Test Python Actions
 on:
   push:
     tags: ["*"]
-    branches: [main]
-    paths: ["signature/**", ".github/workflows/test-signature.yml"]
+    branches:
+      - main
+      - "v*"
   pull_request:
-    branches: [main]
-    paths: ["signature/**", ".github/workflows/test-signature.yml"]
 
 jobs:
   test-creating-signature-file:


### PR DESCRIPTION
## What

Always run testing workflows

## Why

Allow to require successfully running workflows by always running them.

There is only one additional not satisfying work around for the problem https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks

