### PR TITLE
Add: Add a link to using conventional commits docs

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,12 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+
+jobs:
+  conventional-commits:
+    name: Report Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+        - name: Report Conventional Commits
+          uses: greenbone/actions/conventional-commits@v2

--- a/conventional-commits/README.md
+++ b/conventional-commits/README.md
@@ -6,17 +6,17 @@ To run this action you need to add the following code to your workflow file
 (for example `.github/workflows/backport.yml`):
 
 ```yml
-name: Backport
+name: Conventional Commits
 
 on:
   pull_request:
 
 jobs:
   conventional-commits:
-    name: Check for Conventional Commits
+    name: Report Conventional Commits
     runs-on: ubuntu-latest
     steps:
-        - name: Backport Pull Request
+        - name: Report Conventional Commits
           uses: greenbone/actions/conventional-commits@v2
           with:
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/conventional-commits/action/commits.py
+++ b/conventional-commits/action/commits.py
@@ -100,6 +100,12 @@ class Commits:
             comment_lines.append(":rocket: Conventional commits found.")
         else:
             comment_lines.append(":cry: No conventional commits found.")
+            comment_lines.append("")
+            # pylint: disable=line-too-long
+            comment_lines.append(
+                ":point_right: [Learn more](https://github.com/greenbone/.github/blob/main/conventional-commits/README.md) "
+                "about the conventional commits usage at [Greenbone](https://github.com/greenbone/)."
+            )
 
         cc_report_comment = None
 


### PR DESCRIPTION
## What

Add a link to using conventional commits docs

## Why

When creating a PR comment if no conventional commits are found add a link to the usage docs for conventional commits at Greenbone.

## References

DEVOPS-654