### PR TITLE
Change: Only checkout repo during release if there is no checkout

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -54,7 +54,17 @@ runs:
   using: "composite"
   steps:
     # Setup
+    - name: Checkout exists already
+      id: checkout
+      run: |
+        if [[ -d "${{ github.workspace }}/.git" ]]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
     - uses: actions/checkout@v3
+      if: steps.checkout.outputs.exists != 'true'
       with:
         fetch-depth: 0 #for conventional commits
         persist-credentials: false


### PR DESCRIPTION
## What

Only checkout repo during release if there is no checkout

## Why

Avoid running the checkout twice during a release. When using release within a workflow or another action that requires a previous checkout avoid overriding the code by running checkout again.

Required for creating a release for the actions repo.

