### PR TITLE
Change: Always use Python 3.10 as default

### DIFF
--- a/backport-pull-request/action.yml
+++ b/backport-pull-request/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@main
       with:
-        version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
         working-directory: ${{ github.action_path }}
         without-dev: "true"

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@main
       with:
-        version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
         working-directory: ${{ github.action_path }}
         without-dev: "true"

--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -8,6 +8,7 @@ inputs:
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."
   python-version:
     description: "Python version that should be installed"
+    default: "3.10"
   test-command:
     description: "Command to run the tests"
     required: true

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -58,7 +58,7 @@ runs:
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@main
       with:
-        version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
         working-directory: ${{ github.action_path }}
         without-dev: "true"

--- a/helm-version-upgrade/action.yml
+++ b/helm-version-upgrade/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@v2
       with:
-        version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         working-directory: ${{ github.action_path }}
         without-dev: "true"
         poetry-version: ${{ inputs.poetry-version }}

--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -11,6 +11,7 @@ inputs:
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."
   python-version:
     description: "Python version that should be installed"
+    default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
   cache:

--- a/mypy-python/action.yaml
+++ b/mypy-python/action.yaml
@@ -11,6 +11,7 @@ inputs:
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."
   python-version:
     description: "Python version that should be installed"
+    default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
   cache:

--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -24,7 +24,7 @@ inputs:
     description: "Use a specific poetry version. By default the latest release is used."
   python-version:
     description: "Python version that should be installed and used."
-    default: "3.9"
+    default: "3.10"
 branding:
   icon: "package"
   color: "green"

--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@main
       with:
-        version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
         working-directory: ${{ github.action_path }}
         without-dev: "true"

--- a/update-header/action.yaml
+++ b/update-header/action.yaml
@@ -44,7 +44,7 @@ runs:
     - name: Set up Poetry, python and the project
       uses: greenbone/actions/poetry@v2
       with:
-        version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
     - name: Virtual Environment
       id: virtualenv


### PR DESCRIPTION


## What

Always use Python 3.10 as default

## Why
We should use an up to date Python version for all our actions as default.