### PR TITLE
Fix: Don't use ${{}} in message text because it gets escaped

### DIFF
--- a/reference-version/action.yaml
+++ b/reference-version/action.yaml
@@ -23,7 +23,7 @@ runs:
           echo "REF=${GITHUB_REF}" >> $GITHUB_ENV;
           echo "VERSION=${GITHUB_REF##refs/*/}" >> $GITHUB_ENV;
         fi;
-        echo "::warning title=reference-version is deprecated:: The reference-version action is deprecated. Please use ${{ github.ref_name }} instead. See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context for more details."
+        echo "::warning title=reference-version is deprecated:: The reference-version action is deprecated. Please use `github.ref_name` instead. See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context for more details."
       shell: bash
       name: Set version in environment
     - run: |


### PR DESCRIPTION
## What

Don't use ${{}} in message text because it gets escaped

## Why

Fix printing the deprecation message of reference-version. Only show the variable name here without the full GitHub Actions variable syntax. Otherwise it will be replaced with the content of the variable.
