### PR TITLE
Fix: Use correct URL for setup-pontos action

### DIFF
--- a/check-version/action.yaml
+++ b/check-version/action.yaml
@@ -19,7 +19,7 @@ runs:
   steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ inputs.python-version }} and pontos
-      uses: actions/setup-pontos@v2
+      uses: greenbone/actions/setup-pontos@v2
       id: virtualenv
       with:
         python-version: ${{ inputs.python-version}}


### PR DESCRIPTION
## What

Use correct URL for setup-pontos action

## Why
Wrong action path

## References

https://github.com/greenbone/scan-management-backend/actions/runs/4913067701/jobs/8772894775?pr=52

