### PR TITLE
Fix: Include python version in cache key for setup-pontos

### DIFF
--- a/setup-pontos/action.yml
+++ b/setup-pontos/action.yml
@@ -34,6 +34,7 @@ runs:
         echo "activate=${{ inputs.virtualenv-path }}/bin/activate" >> $GITHUB_OUTPUT
       shell: bash
     - name: Set up Python ${{ inputs.python-version }}
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
## What

Include python version in cache key for setup-pontos

## Why

The id on setup-python action to allow getting the installed python version afterwards to include it in the cache key

