### PR TITLE
Fix: Don't set gpg key in release action

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -106,13 +106,6 @@ runs:
         user: ${{ inputs.github-user }}
         mail: ${{ inputs.github-user-mail }}
         token: ${{ inputs.github-user-token }}
-    - name: Import gpg key from secrets
-      run: |
-        echo -e "${{ inputs.gpg-key }}" >> tmp.file
-        gpg --pinentry-mode loopback --passphrase ${{ inputs.gpg-passphrase }} --import tmp.file
-        rm tmp.file
-      shell: bash
-      if: ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
 
       # Input parsing
     - name: Parse release-type


### PR DESCRIPTION

## What

Don't set gpg key in release action

## Why

The gpg key is not used in the release action (at least at the moment). The gpg key is only used in the sign-release-files action.

This fixes the release when files should be signed because importing a gpg key twice results in a gpg error.


