### PR TITLE
Fix: Adjust cache key for release and mattermost-notify virtualenvs

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -25,8 +25,8 @@ runs:
     - name: Virtual Environment
       id: virtualenv
       run: |
-        echo "path=${{ github.action_path }}/${{ github.action }}-venv" >> $GITHUB_OUTPUT
-        echo "name=${{ github.action }}-venv" >> $GITHUB_OUTPUT
+        echo "path=${{ github.action_path }}/mattermost-notify-venv" >> $GITHUB_OUTPUT
+        echo "name=mattermost-notify-venv" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache Virtual Environment
       id: cache-virtualenv

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -80,8 +80,8 @@ runs:
     - name: Virtual Environment
       id: virtualenv
       run: |
-        echo "path=${{ github.action_path }}/${{ github.action }}-venv" >> $GITHUB_OUTPUT
-        echo "name=${{ github.action }}-venv" >> $GITHUB_OUTPUT
+        echo "path=${{ github.action_path }}/release-action-venv" >> $GITHUB_OUTPUT
+        echo "name=release-action-venv" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache Virtual Environment
       id: cache-virtualenv


### PR DESCRIPTION


## What

Adjust cache key for release and mattermost-notify virtualenvs

## Why

Sadly github.action evaluates to the same string in all our actions due to our single actions repo usage. Therefore set a distinct key for the release and mattermost-notify Python virtual environments in the cache.