### PR TITLE
Add: Add version outputs for release action

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -49,6 +49,20 @@ inputs:
     description: "Update version in project files like `pyproject.toml`. Default is 'true'. Set to an other string then 'true' to disable updating project files."
     default: "true"
 
+outputs:
+  release-version:
+    description: "Version of the release. Depending on the inputs it is calculated from the detected last release version."
+    value: ${{ steps.release.outputs.release-version }}
+  last-release-version:
+    description: "Detected version of the previous release."
+    value: ${{ steps.release.outputs.last-release-version }}
+  git-release-tag:
+    description: "Git tag created for the release version"
+    value: ${{ steps.release.outputs.git-release-tag }}
+  next-version:
+    description: "Version set after a successful release"
+    value: ${{ steps.release.outputs.next-version }}
+
 branding:
   icon: "package"
   color: "green"
@@ -159,4 +173,4 @@ runs:
         gpg-passphrase: ${{ inputs.gpg-passphrase }}
         versioning-scheme: ${{ inputs.versioning-scheme }}
         release-series: ${{ inputs.release-series }}
-        release-version: ${{ inputs.release-version }}
+        release-version: ${{ steps.release.outputs.release-version }}


### PR DESCRIPTION


## What

Add version outputs for release action

## Why

Allow to get the versions determined and used by the release action via action outputs.

This will allow to actually split a release workflow into several steps.

## References

Requires https://github.com/greenbone/pontos/pull/770


