### PR TITLE
Add: Add deprecation messages for release input arguments

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -6,6 +6,7 @@ description: |
 
 inputs:
   conventional-commits:
+    deprecationMessage: "conventional-commits input is obsolete. Using conventional commits is always expected."
     description: "Deprecated."
   github-user:
     description: "Github user name on behalf of whom the actions will be executed."
@@ -23,6 +24,7 @@ inputs:
   gpg-passphrase:
     description: "GPG passphrase, represented as a string. Required for signing assets of the release."
   strategy:
+    deprecationMessage: "strategy input is deprecated. Please use `release-type` instead."
     description: "Deprecated by release-type."
   python-version:
     description: "Python version used  to create the release. (Only important for python projects)"


### PR DESCRIPTION

## What

Add deprecation messages for release input arguments
## Why

Show deprecation messages when strategy and conventional-commits inputs of the release action are used to make users aware of the changes.