### PR TITLE
Add: Include dependency updates in release changelogs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,46 +5,79 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/poetry/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/release/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/release-python/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/coverage-python/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/lint-python/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/mypy-python/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/mattermost-notify/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/install-npm/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/lint-javascript/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/test-javascript/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
 
     # PIP
   - package-ecosystem: pip
@@ -55,6 +88,9 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: pip
     directory: "/download-artifact/"
     schedule:
@@ -63,6 +99,9 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
   - package-ecosystem: pip
     directory: "/backport-pull-request/"
     schedule:
@@ -71,3 +110,6 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
+      include: "scope"


### PR DESCRIPTION


## What

Update dependabot config to create commits which use conventional commit messages.

## Why

Include dependency updates in release changelogs

## References

DEVOPS-669

