### PR TITLE
Change: Use v2 actions in main

### DIFF
--- a/backport-pull-request/action.yml
+++ b/backport-pull-request/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python and Poetry
-      uses: greenbone/actions/poetry@main
+      uses: greenbone/actions/poetry@v2
       with:
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -23,7 +23,7 @@ runs:
       with:
         fetch-depth: 0
     - name: Set up Python and Poetry
-      uses: greenbone/actions/poetry@main
+      uses: greenbone/actions/poetry@v2
       with:
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -56,7 +56,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python and Poetry
-      uses: greenbone/actions/poetry@main
+      uses: greenbone/actions/poetry@v2
       with:
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}

--- a/mypy-python/action.yaml
+++ b/mypy-python/action.yaml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Install poetry
-      uses: greenbone/actions/poetry@main
+      uses: greenbone/actions/poetry@v2
       with:
         version: ${{ inputs.version }}
         python-version: ${{ inputs.python-version }}

--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python and Poetry
-      uses: greenbone/actions/poetry@main
+      uses: greenbone/actions/poetry@v2
       with:
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}


### PR DESCRIPTION
## What

Use v2 actions in main

## Why

When using our own action in a composite action always use the v2 version in the main branch too. This prepares for a possible switch from a v2 branch to a v2 tag.

## References

DEVOPS-679