### PR TITLE
Change: Cleanup all workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,12 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "main", v*, v2 ]
+    branches:
+      - main
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches:
+      - main
   schedule:
     - cron: '33 15 * * 5'
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   conventional-commits:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,7 @@
-name: 'Dependency Review'
-on: [pull_request]
+name: Dependency Review
+
+on:
+  pull_request:
 
 permissions:
   contents: read
@@ -8,5 +10,5 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Dependency Review'
+      - name: Dependency Review
         uses: greenbone/actions/dependency-review@v2

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -2,7 +2,9 @@ name: SBOM upload
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches:
+      - main
+
 jobs:
   SBOM-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-doc-coverage.yml
+++ b/.github/workflows/test-doc-coverage.yml
@@ -2,12 +2,19 @@ name: Test Doc Coverage Actions
 
 on:
   push:
-    tags: ["*"]
-    branches: [main]
-    paths: [ "doc-coverage-clang/**", ".github/workflows/test-doc-coverage.yml" ]
+    tags:
+      - "v*"
+    branches:
+      - main
+    paths:
+      - "doc-coverage-clang/**"
+      - ".github/workflows/test-doc-coverage.yml"
   pull_request:
-    branches: [main]
-    paths: ["doc-coverage-clang/**", ".github/workflows/test-doc-coverage.yml"]
+    branches:
+      - main
+    paths:
+      - "doc-coverage-clang/**"
+      - ".github/workflows/test-doc-coverage.yml"
 
 jobs:
   test-doc-cov-clang:

--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "v*"
   pull_request:
 
 jobs:
@@ -15,12 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Determine Branch
+        id: branch
         run: |
           if [ -n "$GITHUB_HEAD_REF" ];
           then
-            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV;
+            echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT;
           else
-            echo "BRANCH=${GITHUB_REF##refs/*/}" >> $GITHUB_ENV;
+            echo "branch=${GITHUB_REF##refs/*/}" >> $GITHUB_OUTPUT;
           fi;
         shell: bash
       - name: Trigger Artifact Uploading
@@ -29,14 +29,14 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
-          ref: ${{ env.BRANCH }}
+          ref: ${{ steps.branch.outputs.branch }}
       - name: Download Artifact
         uses: ./download-artifact
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
-          branch: ${{ env.BRANCH }}
+          branch: ${{ steps.branch.outputs.branch }}
           name: artifact
       - name: Download Artifacts
         uses: ./download-artifact
@@ -44,14 +44,14 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
-          branch: ${{ env.BRANCH }}
+          branch: ${{ steps.branch.outputs.branch }}
       - name: Ignore missing workflow
         uses: ./download-artifact
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "foo-bar.yml"
-          branch: ${{ env.BRANCH }}
+          branch: ${{ steps.branch.outputs.branch }}
           name: artifact
           allow-not-found: true
       - name: Ignore missing artifact
@@ -60,6 +60,6 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-download-artifacts-test-workflow.yml"
-          branch: ${{ env.BRANCH }}
+          branch: ${{ steps.branch.outputs.branch }}
           name: foo
           allow-not-found: true

--- a/.github/workflows/test-hashsums.yml
+++ b/.github/workflows/test-hashsums.yml
@@ -2,10 +2,10 @@ name: Test Python Actions
 
 on:
   push:
-    tags: ["*"]
+    tags:
+      - "v*"
     branches:
       - main
-      - "v*"
   pull_request:
 
 jobs:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,10 +2,10 @@ name: Test Python Actions
 
 on:
   push:
-    tags: [ "*" ]
+    tags:
+      - "v*"
     branches:
       - main
-      - "v*"
   pull_request:
 
 jobs:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -2,12 +2,21 @@ name: Test Release Actions
 
 on:
   push:
-    tags: [ "*" ]
-    branches: [ main ]
-    paths: [ "release/**","release-python/**", ".github/workflows/test-release.yml" ]
+    tags:
+      - "v*"
+    branches:
+      - main
+    paths:
+      - "release/**"
+      - "release-python/**"
+      - ".github/workflows/test-release.yml"
   pull_request:
-    branches: [ main ]
-    paths: [ "release/**","release-python/**", ".github/workflows/test-release.yml" ]
+    branches:
+      - main
+    paths:
+      - "release/**"
+      - "release-python/**"
+      - ".github/workflows/test-release.yml"
 
 jobs:
   release-patch-cc:

--- a/.github/workflows/test-signature.yml
+++ b/.github/workflows/test-signature.yml
@@ -2,10 +2,10 @@ name: Test Python Actions
 
 on:
   push:
-    tags: ["*"]
+    tags:
+      - "v*"
     branches:
       - main
-      - "v*"
   pull_request:
 
 jobs:

--- a/.github/workflows/test-trigger-workflow.yml
+++ b/.github/workflows/test-trigger-workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "v*"
   pull_request:
 
 jobs:
@@ -15,12 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Determine Ref
+        id: ref
         run: |
           if [ -n "$GITHUB_HEAD_REF" ];
           then
-            echo "REF=${GITHUB_HEAD_REF}" >> $GITHUB_ENV;
+            echo "ref=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT;
           else
-            echo "REF=${GITHUB_REF##refs/*/}" >> $GITHUB_ENV;
+            echo "ref=${GITHUB_REF##refs/*/}" >> $GITHUB_OUTPUT;
           fi;
         shell: bash
       - name: Trigger Another Workflow
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-trigger-workflow-long-running-workflow.yml"
-          ref: ${{ env.REF }}
+          ref: ${{ steps.ref.outputs.ref }}
           wait-for-completion-timeout: 10
           wait-for-completion-interval: 10
       - name: Fail if not failed
@@ -47,12 +47,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Determine Ref
+        id: ref
         run: |
           if [ -n "$GITHUB_HEAD_REF" ];
           then
-            echo "REF=${GITHUB_HEAD_REF}" >> $GITHUB_ENV;
+            echo "ref=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT;
           else
-            echo "REF=${GITHUB_REF##refs/*/}" >> $GITHUB_ENV;
+            echo "ref=${GITHUB_REF##refs/*/}" >> $GITHUB_OUTPUT;
           fi;
         shell: bash
       - name: Trigger Another Workflow
@@ -61,7 +62,7 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-trigger-workflow-test-workflow.yml"
-          ref: ${{ env.REF }}
+          ref: ${{ steps.ref.outputs.ref }}
           wait-for-completion-interval: 10
 
   test-failing-workflow:
@@ -71,12 +72,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Determine Ref
+        id: ref
         run: |
           if [ -n "$GITHUB_HEAD_REF" ];
           then
-            echo "REF=${GITHUB_HEAD_REF}" >> $GITHUB_ENV;
+            echo "ref=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT;
           else
-            echo "REF=${GITHUB_REF##refs/*/}" >> $GITHUB_ENV;
+            echo "ref=${GITHUB_REF##refs/*/}" >> $GITHUB_OUTPUT;
           fi;
         shell: bash
       - name: Trigger Another Workflow
@@ -87,7 +89,7 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: greenbone/actions
           workflow: "test-trigger-workflow-failing-workflow.yml"
-          ref: ${{ env.REF }}
+          ref: ${{ steps.ref.outputs.ref }}
       - name: Fail if not failed
         if: ${{ success() && steps.test.outcome != 'failure' }}
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,7 +2,8 @@ name: Run unittests
 
 on:
   push:
-    tags: [ "*" ]
+    tags:
+      - "v*"
     branches:
       - main
   pull_request:


### PR DESCRIPTION
## What

Cleanup all workflows

## Why

Use consistent specification of events, used branches and tags. Use GITHUB_OUTPUT instead of GITHUB_ENV where applicable. Using the env pollutes the environment of **all** following steps. Therefore it should only be used for setting required environment variables.

