### PR TITLE
Fix: Don't require packages input for mypy action

### DIFF
--- a/mypy-python/action.yaml
+++ b/mypy-python/action.yaml
@@ -1,12 +1,11 @@
 name: "Python Mypy Action"
-author: "Tom Ricciuti <tom.ricciuti@greenbone.net>"
+author: "Björn Ricks <bjoern.ricks@greenbone.net>"
 description: "An action that verifies python type hints by using mypy"
 
 inputs:
   packages:
     description: "Python packages to check with mypy"
     deprecationMessage: "packages input is deprecated. Please use `mypy-arguments` input instead."
-    required: true
   version:
     description: "Python version that should be installed. Deprecated: Use `python-version` input instead."
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."


### PR DESCRIPTION
## What

Don't require packages input for mypy action

## Why

packages input argument is deprecated and therefore not required anymore.

