### PR TITLE
Add: Allow MIT AND Python-2.0 as valid license

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -32,4 +32,5 @@ runs:
           CC-BY-SA-4.0,
           BSD-2-Clause AND BSD-3-Clause,
           MIT OR Apache-2.0,
+          MIT AND Python-2.0,
           (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT)


### PR DESCRIPTION


## What

Allow MIT AND Python-2.0 as valid license

## Why

Allow MIT and Python-2.0 as allowed licenses for using the [exceptiongroup](https://github.com/agronholm/exceptiongroup) backport as a (sub-)dependency. It got required with the latest anyio update. See for example https://github.com/greenbone/pontos/actions/runs/5119229445

## References

For example:
https://github.com/greenbone/pontos/actions/runs/5119229445
https://github.com/greenbone/pontos/pull/784