### PR TITLE
Add: Add new actions release-type and is-latest-tag

### DIFF
--- a/is-latest-tag/README.md
+++ b/is-latest-tag/README.md
@@ -1,0 +1,30 @@
+# Is Latest Tag
+
+GitHub Action to check if a git tag is the latest tag
+
+## Example
+
+```yml
+name: Check Tag
+
+on:
+  tag:
+
+jobs:
+  check:
+    name: Check Tag
+    runs-on: ubuntu-latest
+    steps:
+        - uses: greenbone/actions/is-latest-tag@v2
+          id: latest
+        - name:
+          if: steps.latest.outputs.is-latest-tag
+          run: |
+            # do something if the current tag is the latest tag
+```
+
+## Output Arguments
+
+|Output Variable|Description|
+|---------------|-----------|
+| is-latest-tag | Evaluates to true if the created tag is the latest git tag |

--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -1,0 +1,40 @@
+name: "Check if a tag is the latest tag in a repository"
+author: "Björn Ricks <bjoern.ricks@greenbone.net>"
+description: "An action to check if a tag is the latest tag in a repository"
+
+outputs:
+  is-latest-tag:
+    description: Evaluates to true if the created tag is the latest git tag
+    value: ${{ steps.latest.outputs.is-latest-tag }}
+
+branding:
+  icon: "package"
+  color: "green"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "set is-latest-tag"
+      id: latest
+      run: |
+        # find the latest version that is not ourself
+        export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort)
+
+        # get major minor patch versions
+        IFS='.' read -r latest_major latest_minor latest_patch << EOF
+        $LATEST_VERSION
+        EOF
+
+        IFS='.' read -r tag_major tag_minor tag_patch << EOF
+        ${{ github.ref_name }}
+        EOF
+
+        # remove leading v
+        latest_major=$(echo $latest_major | cut -c2-)
+        tag_major=$(echo $tag_major | cut -c2-)
+
+        echo "$tag_major >= $latest_major"
+        if [[ $tag_major -ge $latest_major && ($tag_minor -ne 0 || $tag_patch -ne 0) ]]; then
+          echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash

--- a/release-type/README.md
+++ b/release-type/README.md
@@ -1,0 +1,51 @@
+# Release Type
+
+GitHub Action to determine the release type and release reference
+
+## Example
+
+```yml
+name: Determine Release Type
+
+on:
+  pull_request:
+    type: [closed]
+  workflow_dispatch:
+      release-type:
+        type: choice
+        description: What kind of release do you want to do (pontos --release-type argument)?
+        options:
+          - patch
+          - minor
+          - major
+          - release-candidate
+          - alpha
+          - beta
+
+jobs:
+  check:
+    name: Determine Release Type and Ref
+    runs-on: ubuntu-latest
+    steps:
+        - uses: greenbone/actions/release-type@v2
+          id: release
+          with:
+            release-type-input: ${{ inputs.release-type }}
+        - name: Print release type and ref
+          run: |
+            echo ${{ steps.release.outputs.release-type }}
+            echo ${{ steps.release.outputs.release-ref }}
+```
+
+## Action Configuration
+
+|Input Variable|Description| |
+|--------------|-----------|-|
+| release-type-input | Release type for workflow dispatch based manual release. If not set the release type will be derived from the pull request labels. | Optional |
+
+## Output Arguments
+
+|Output Variable|Description|
+|---------------|-----------|
+| release-type | Determined release type based on input and set pull requests labels |
+| release-ref  | Determined release reference |

--- a/release-type/action.yml
+++ b/release-type/action.yml
@@ -1,0 +1,68 @@
+name: "Determine Release Type and Reference"
+author: "Björn Ricks <bjoern.ricks@greenbone.net>"
+description: "An action to determine the release type and release reference"
+
+inputs:
+  release-type-input:
+    description: "Release type for workflow dispatch based manual release. If not set the release type will be derived from the pull request labels."
+
+outputs:
+  release-type:
+    description: Determined release type based on input and set pull requests labels
+    value: ${{ steps.release.outputs.release-type }}
+  release-ref:
+    description: Determined release reference
+    value: ${{ steps.ref.outputs.ref }}
+
+branding:
+  icon: "package"
+  color: "green"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Selecting the Release type
+      if: contains(github.event.pull_request.labels.*.name, 'major release')
+      run: |
+        echo "RELEASE_TYPE=major" >> $GITHUB_ENV
+      shell: bash
+    - if: contains(github.event.pull_request.labels.*.name, 'minor release')
+      run: |
+        echo "RELEASE_TYPE=minor" >> $GITHUB_ENV
+      shell: bash
+    - if: contains(github.event.pull_request.labels.*.name, 'patch release')
+      run: |
+        echo "RELEASE_TYPE=patch" >> $GITHUB_ENV
+      shell: bash
+    - if: contains(github.event.pull_request.labels.*.name, 'rc release')
+      run: |
+        echo "RELEASE_TYPE=release-candidate" >> $GITHUB_ENV
+      shell: bash
+    - if: contains(github.event.pull_request.labels.*.name, 'alpha release')
+      run: |
+        echo "RELEASE_TYPE=alpha" >> $GITHUB_ENV
+      shell: bash
+    - if: contains(github.event.pull_request.labels.*.name, 'beta release')
+      run: |
+        echo "RELEASE_TYPE=beta" >> $GITHUB_ENV
+      shell: bash
+    - name: Workflow_dispatch RELEASE_TYPE
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "RELEASE_TYPE=${{ inputs.release-type-input }}" >> $GITHUB_ENV
+      shell: bash
+    - name: Echoing the release type
+      id: release
+      run: |
+        echo "Release type is $RELEASE_TYPE"
+        echo "release-type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Setting the Reference
+      id: ref
+      run: |
+        if [[ "${{ github.event_name }}" = "workflow_dispatch" ]]; then
+          echo "ref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+        fi
+      shell: bash


### PR DESCRIPTION
## What

Add new actions release-type and is-latest-tag

## Why

Add two new actions for supporting creating releases. release-type determines the release type from PR labels or input. is-latest-tag checks if a new tag is the latest tag.

## References

https://github.com/greenbone/gvmd/pull/2005

