### PR TITLE
Fix: Fix is-latest-tag action for non tag based events

### DIFF
--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -17,24 +17,30 @@ runs:
     - name: "set is-latest-tag"
       id: latest
       run: |
-        # find the latest version that is not ourself
-        export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort)
+        if [ "${{ github.ref_type }}" = "tag" ]; then
+          # find the latest version that is not ourself
+          export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort)
 
-        # get major minor patch versions
-        IFS='.' read -r latest_major latest_minor latest_patch << EOF
-        $LATEST_VERSION
-        EOF
+          # get major minor patch versions
+          IFS='.' read -r latest_major latest_minor latest_patch << EOF
+          $LATEST_VERSION
+          EOF
 
-        IFS='.' read -r tag_major tag_minor tag_patch << EOF
-        ${{ github.ref_name }}
-        EOF
+          IFS='.' read -r tag_major tag_minor tag_patch << EOF
+          ${{ github.ref_name }}
+          EOF
 
-        # remove leading v
-        latest_major=$(echo $latest_major | cut -c2-)
-        tag_major=$(echo $tag_major | cut -c2-)
+          # remove leading v
+          latest_major=$(echo $latest_major | cut -c2-)
+          tag_major=$(echo $tag_major | cut -c2-)
 
-        echo "$tag_major >= $latest_major"
-        if [[ $tag_major -ge $latest_major && ($tag_minor -ne 0 || $tag_patch -ne 0) ]]; then
-          echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+          echo "$tag_major >= $latest_major"
+          if [[ $tag_major -ge $latest_major && ($tag_minor -ne 0 || $tag_patch -ne 0) ]]; then
+            echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-latest-tag=false" >> $GITHUB_OUTPUT
+          fi
+        else
+            echo "is-latest-tag=false" >> $GITHUB_OUTPUT
         fi
       shell: bash


### PR DESCRIPTION
## What

Fix is-latest-tag action for non tag based events
## Why

Ensure is-latest-tag output is always set and the action doesn't fail if the workflow event is not a tag.

## References

https://github.com/greenbone/gvmd/actions/runs/5201011510/jobs/9397262925?pr=2005
