### PR TITLE
Fix: Fix is-latest-tag EOF usage

### DIFF
--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -23,12 +23,12 @@ runs:
 
           # get major minor patch versions
           IFS='.' read -r latest_major latest_minor latest_patch << EOF
-          $LATEST_VERSION
-          EOF
+        $LATEST_VERSION
+        EOF
 
           IFS='.' read -r tag_major tag_minor tag_patch << EOF
-          ${{ github.ref_name }}
-          EOF
+        ${{ github.ref_name }}
+        EOF
 
           # remove leading v
           latest_major=$(echo $latest_major | cut -c2-)


### PR DESCRIPTION


## What

Fix is-latest-tag EOF usage

## Why

EOF needs to be directly at the start of the line and must not be indented.

## References

https://github.com/greenbone/gvmd/actions/runs/5208881814/jobs/9398012007?pr=2005


