### PR TITLE
Fix failing download of sbom-tool

### DIFF
--- a/sbom-upload/action.yml
+++ b/sbom-upload/action.yml
@@ -9,7 +9,7 @@ runs:
     - uses: actions/checkout@v3
     - name: Generate SBOM
       run: |
-        curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
+        curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/download/v1.1.2/sbom-tool-linux-x64
         chmod +x $RUNNER_TEMP/sbom-tool
         $RUNNER_TEMP/sbom-tool generate -b . -bc . -pn ${{ github.repository }} -pv 1.0.0 -ps "Greenbone AG" -nsb https://greenbone.net -V Verbose
       shell: bash


### PR DESCRIPTION
# What

Use a known-good release of `sbom-tool` to download the binary as a workaround, as binaries for the `latest` release are currently not available (see https://github.com/microsoft/sbom-tool/issues/271 ).

