### PR TITLE
Allow 0BSD license

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -15,6 +15,7 @@ runs:
         vulnerability-check: true
         license-check: true
         allow-licenses: |
+          0BSD,
           AGPL-3.0-or-later,
           GPL-3.0-or-later,
           LGPL-2.1,


### PR DESCRIPTION
## What
Add 0BSD (BSD Zero Clause License) to action.yml

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The license is compatible with our useage and came up as "not allowed" in the dependency review. According to internal documentation, 0BSD should have been allowed already.

<!-- Describe why are these changes necessary? -->

## References
https://github.com/greenbone/scan-management-frontend/actions/runs/5245115892/jobs/9472098011?pr=700
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

