### PR TITLE
Add: Allow GPL-3.0-or-later and LGPL-2.1-only

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -23,6 +23,7 @@ runs:
           Python-2.0,
           GPL-2.0-or-later,
           GPL-2.0-only,
+          GPL-3.0-or-later AND LGPL-2.1-only,
           MIT,
           ISC,
           Unlicense,


### PR DESCRIPTION


## What

Allow GPL-3.0-or-later and LGPL-2.1-only

## Why

GitHub reports GPL-3.0-or-later AND LGPL-2.1-only for the astroid Python package