### PR TITLE
Improve check for signing action

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -167,7 +167,7 @@ runs:
       # Signing
     - name: Sign assets for released version
       uses: greenbone/actions/sign-release-files@v2
-      if: ${{ inputs.sign-release-files == 'true' }} && ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
+      if: inputs.sign-release-files == 'true' && inputs.gpg-key && inputs.gpg-fingerprint && inputs.gpg-passphrase
       with:
         python-version: ${{ inputs.python-version }}
         github-token: ${{ inputs.github-user-token }}

--- a/sign-release-files/action.yml
+++ b/sign-release-files/action.yml
@@ -36,6 +36,24 @@ runs:
   using: "composite"
   steps:
     # Setup
+    - name: Check gpg-key input
+      if: inputs.gpg-key == ''
+      run: |
+        echo "::error ::gpg-key input is missing."
+        exit 1
+      shell: bash
+    - name: Check gpg-fingerprint input
+      if: inputs.gpg-fingerprint == ''
+      run: |
+        echo "::error ::gpg-fingerprint input is missing."
+        exit 1
+      shell: bash
+    - name: Check gpg-passphrase input
+      if: inputs.gpg-passphrase == ''
+      run: |
+        echo "::error ::gpg-passphrase input is missing."
+        exit 1
+      shell: bash
     - name: Parse release-version if set (overwrite release-type)
       if: ${{ inputs.release-version }}
       run: |


### PR DESCRIPTION
## What

Fix and improve release without signing

## Why

It seems the signing is always run at the moment despite setting `sign-release-files` to a value other then "true".

## References

https://github.com/greenbone/gsa/actions/runs/5421140342/jobs/9856197131