### PR TITLE
Change: Run enforce-admins and lock-branch from pontos package

### DIFF
--- a/admin-bypass/action.yaml
+++ b/admin-bypass/action.yaml
@@ -42,8 +42,7 @@ runs:
     - name: Prepare release and store the version
       run: |
         source ${{ steps.virtualenv.outputs.activate }}
-        wget https://github.com/greenbone/pontos/raw/main/scripts/github/enforce-admins.py -O ~/enforce-admins.py
-        pontos-github-script ~/enforce-admins.py ${{ inputs.repository }} ${{ inputs.branch }} ${{ env.ALLOW_OPT }}
+        pontos-github-script pontos.github.scripts.enforce-admins ${{ inputs.repository }} ${{ inputs.branch }} ${{ env.ALLOW_OPT }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/lock-branch/action.yaml
+++ b/lock-branch/action.yaml
@@ -45,8 +45,7 @@ runs:
     - name: Prepare release and store the version
       run: |
         source ${{ steps.virtualenv.outputs.activate }}
-        wget https://github.com/greenbone/pontos/raw/main/scripts/github/lock-branch.py -O ~/lock-branch.py
-        pontos-github-script ~/lock-branch.py ${{ inputs.repository }} ${{ inputs.branch }} ${{ env.LOCK_OPT }}
+        pontos-github-script pontos.github.scripts.lock-branch ${{ inputs.repository }} ${{ inputs.branch }} ${{ env.LOCK_OPT }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION

## What

Run enforce-admins and lock-branch from pontos package

Requires https://github.com/greenbone/pontos/releases/tag/v23.7.0

## Why

All GitHub scripts are provided with the latest pontos package. Therefore there is no need in downloading them from the repo anymore.