### PR TITLE
Add: Allow to specify refs for conventional commits action

### DIFF
--- a/conventional-commits/README.md
+++ b/conventional-commits/README.md
@@ -51,3 +51,5 @@ jobs:
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
 | poetry-version | Poetry version to use for running the action. | Optional (default is latest) |
 | cache-poetry-installation | Cache poetry and its dependencies. | Optional (default is `"true"`) |
+| ref | The branch, tag or SHA to checkout. | Optional. Default of [actions/checkout](https://github.com/actions/checkout). |
+| base-ref | Use a specific base ref. | Optional. (default is [`${{ github.base_ref }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) |

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -14,6 +14,11 @@ inputs:
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"
+  ref:
+    description: "The branch, tag or SHA to checkout."
+  base-ref:
+    description: "Use a specific base ref. Defaults to 'github.base_ref'."
+    default: ${{ github.base_ref }}
 
 runs:
   using: "composite"
@@ -22,6 +27,7 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.ref }}
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@v2
       with:
@@ -37,7 +43,7 @@ runs:
       run: |
         poetry run conventional-commits \
           --token ${{ inputs.token }} \
-          --base-ref ${{ github.base_ref }} \
+          --base-ref ${{ inputs.base-ref }} \
           --event-path ${{ github.event_path }} \
           --repository ${{ github.repository }} \
           --working-directory ${{ github.workspace }}


### PR DESCRIPTION
## What

Allow to specify refs for conventional commits action

## Why

Allow to adjust the refs for gathering the changes. This is mostly interesting for testing at the moment.

## References

DEVOPS-720