### PR TITLE
Change: Use github-actions user as default for set-github-user

### DIFF
--- a/set-github-user/README.md
+++ b/set-github-user/README.md
@@ -28,7 +28,7 @@ jobs:
 
 |Input Variable|Description| |
 |--------------|-----------|-|
-| user | GitHub user name on behalf of whom the actions will be executed. | Required |
-| mail | Mail address for the given GitHub user. | Required |
+| user | GitHub user name on behalf of whom the actions will be executed. | Optional (default: `github-actions`) |
+| mail | Mail address for the given GitHub user. | Optional (default: `github-actions@github.com`) |
 | token | The GitHub user's token (PAT) | Optional (default: `${{ github.token }}`) |
 | repository | GitHub repository to use | Optional (default: `${{ github.repository }}`) |

--- a/set-github-user/action.yaml
+++ b/set-github-user/action.yaml
@@ -8,16 +8,16 @@ description: |
 
 inputs:
   user:
-    description: "GitHub user name on behalf of whom the actions will be executed."
-    required: true
+    description: "GitHub user name on behalf of whom the actions will be executed. Default is 'github-actions'."
+    default: github-actions
   mail:
-    description: "Mail address for the given GitHub user."
-    required: true
+    description: "Mail address for the given GitHub user. Default is 'github-actions@github.com'."
+    default: github-actions@github.com
   token:
-    description: "The GitHub user's token (PAT)"
+    description: "The GitHub user's token (PAT). Default is github.token."
     default: ${{ github.token }}
   repository:
-    description: "GitHub repository to use"
+    description: "GitHub repository to use. Default is github.repository."
     default: ${{ github.repository }}
 
 runs:


### PR DESCRIPTION


## What

Use github-actions user as default for set-github-user

## Why

Make all inputs optional by just using the github-actions user as default for the git credentials. Allow the action to be used without any input arguments.
