### PR TITLE
Fix fetching commits for conventional commits action

### DIFF
--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -35,7 +35,7 @@ runs:
       # fetch commits from head ref. It stops at base ref because we have a
       # shallow repo.
       run: |
-        git fetch ${{ inputs.head-ref }}
+        git fetch origin ${{ inputs.head-ref }}
       shell: bash
     - name: Set up Python and Poetry
       uses: greenbone/actions/poetry@v2


### PR DESCRIPTION


## What

Fix fetching commits for conventional commits action

## Why

The remote was missing from the fetch statement.

## References
https://github.com/greenbone/pipeline-experiments/actions/runs/5484263979/jobs/9991588937?pr=91

