### PR TITLE
Fix: Ignore version input

### DIFF
--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: "Python packages to lint"
     required: true
   version:
-    description: "Python version that should be installed. Deprecated: Use `python-version` input instead."
+    description: "Deprecated: Use `python-version` input instead. version input is ignored."
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."
   python-version:
     description: "Python version that should be installed"
@@ -41,7 +41,6 @@ runs:
     - name: Install poetry
       uses: greenbone/actions/poetry@v2
       with:
-        version: ${{ inputs.version }}
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
         cache: ${{ inputs.cache }}


### PR DESCRIPTION

## What

Fix: Ignore version input

## Why
Don't forward version input anymore. This resulted in workflow warnings because the deprecation message is raised already if the input is set. Not only if it has a value.

## References

For example https://github.com/greenbone/autohooks-plugin-mypy/actions/runs/5486147206


