### PR TITLE
Add: Print GitHub doc URL if available in conventional commits

### DIFF
--- a/conventional-commits/action/commits.py
+++ b/conventional-commits/action/commits.py
@@ -141,6 +141,8 @@ class Commits:
                 try:
                     json = e.response.json()
                     message = json.get("message")
+                    # some response have links to the docs
+                    doc_url = json.get("documentation_url", "")
                 except JSONDecodeError:
                     message = None
 
@@ -149,7 +151,7 @@ class Commits:
                         "Could not create Pull Request comment. A HTTP "
                         f"{e.response.status_code} error occurred while doing "
                         f"a {e.request.method} request to {e.request.url}. "
-                        f"Error was {message}"
+                        f"Error was '{message}'. {doc_url}"
                     ) from e
                 else:
                     raise CommitsError(


### PR DESCRIPTION


## What

Print GitHub doc URL if available in conventional commits

## Why

Improved error message with details on GitHub. Would be nice to move this also into pontos.
