### PR TITLE
Change: Ignore version input for coverage-python action

### DIFF
--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -4,7 +4,7 @@ description: "An action to upload coverage to codecov.io for Python package by u
 
 inputs:
   version:
-    description: "Python version that should be installed. Deprecated: Use `python-version` input instead."
+    description: "Deprecated: Use `python-version` input instead. version input is ignored."
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."
   python-version:
     description: "Python version that should be installed"
@@ -44,7 +44,6 @@ runs:
     - name: Install poetry
       uses: greenbone/actions/poetry@v2
       with:
-        version: ${{ inputs.version }}
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
         cache: ${{ inputs.cache }}

--- a/mypy-python/action.yaml
+++ b/mypy-python/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: "Python packages to check with mypy"
     deprecationMessage: "packages input is deprecated. Please use `mypy-arguments` input instead."
   version:
-    description: "Python version that should be installed. Deprecated: Use `python-version` input instead."
+    description: "Deprecated: Use `python-version` input instead. version input is ignored."
     deprecationMessage: "version input is deprecated. Please use `python-version` input instead."
   mypy-arguments:
     description: "Additional arguments for running mypy"


### PR DESCRIPTION

## What

Ignore version input for coverage-python action

## Why

Avoid workflow warning when using the action. A deprecation warning is already raised if the input is set and not only if a value is set.
