### PR TITLE
Fix: Remove "MIT/Apache-2.0" from allowed licenses again

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -41,5 +41,3 @@ runs:
           MIT AND Python-2.0,
           (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT),
           (MIT OR Apache-2.0) AND Unicode-DFS-2016,
-          MIT/Apache-2.0
-


### PR DESCRIPTION

## What
Fix: Remove "MIT/Apache-2.0" from allowed licenses again
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Not valid license ...
Licenses only work with "AND" or "OR" ... not with `/` ...

<!-- Describe why are these changes necessary? -->


