### PR TITLE
Fix dependency review action and remove trailing comma

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -40,4 +40,4 @@ runs:
           MIT OR Apache-2.0,
           MIT AND Python-2.0,
           (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT),
-          (MIT OR Apache-2.0) AND Unicode-DFS-2016,
+          (MIT OR Apache-2.0) AND Unicode-DFS-2016


### PR DESCRIPTION


## What

Fix dependency review action and remove trailing comma

## Why
Remove trailing comma at end of allowed licenses. Currently it just always fails.