### PR TITLE
Deps: Use actions/checkout@v3 for doc-coverage-clang and update-header

### DIFF
--- a/doc-coverage-clang/action.yml
+++ b/doc-coverage-clang/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install coverxygen and codecov
       shell: bash
       run: |

--- a/update-header/action.yaml
+++ b/update-header/action.yaml
@@ -37,7 +37,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: ${{ env.FETCH_DEPTH }}
         ref: ${{ inputs.target }}


### PR DESCRIPTION


## What

Use actions/checkout@v3 for doc-coverage-clang and update-header

## Why

v3 of this action got released long time ago.