### PR TITLE
Change: Use release action from main for releasing the actions

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -32,7 +32,7 @@ jobs:
           git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
       - name: Release with release action
         id: release
-        uses: greenbone/actions/release@v2
+        uses: greenbone/actions/release@main
         with:
           github-user: ${{ secrets.GREENBONE_BOT }}
           github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}


### PR DESCRIPTION


## What

Use release action from main for releasing the actions

## Why

This will allow to use changes for the release action in main without having to create a release before. Without the change we need to create an actions release with the old version of the release action to be able to use the new version of the release on the nextnext release. Confused? Therefore this change should be applied.