### PR TITLE
Remove input types from container build actions

### DIFF
--- a/container-build-push-3rd-gen/action.yaml
+++ b/container-build-push-3rd-gen/action.yaml
@@ -2,41 +2,32 @@ name: Container build and push 3rd gen
 description: Container build and push action for 3rd gen.
 
 inputs:
-  build-context: 
+  build-context:
     description: "Path to image build context. Default is the current directory."
-    type: string
     default: .
   build-docker-file:
     description: "Path to the docker file. Default is './Dockerfile'."
-    type: string
     default: ./Dockerfile
   build-args:
     description: "Use these build-args for the docker build process."
-    type: string
     default: ''
   cosign-key:
     description: "cosign key to sign the image."
-    type: string
     default: ''
   cosign-key-password:
     description: "cosign key password."
-    type: string
     default: ''
   image-labels:
     description: "Image labels."
-    type: string
     required: true
   image-url:
     description: "Image url/name without registry."
-    type: string
     required: true
-  image-platforms: 
+  image-platforms:
     description: "Image platforms to build for. Default is 'linux/amd64'."
-    type: string
     default: linux/amd64
   registry-password:
     description: "Registry password."
-    type: string
     required: true
 
 branding:

--- a/container-build-push-docker/action.yaml
+++ b/container-build-push-docker/action.yaml
@@ -1,49 +1,39 @@
 name: Container build and push docker.io
+description: Container build and push action to docker.io
 
 inputs:
-  build-context: 
+  build-context:
     description: "Path to image build context."
-    type: string
     default: .
   build-docker-file:
     description: "Path to the docker file."
-    type: string
     default: ./Dockerfile
   build-args:
     description: "Use these build-args for the docker build process."
-    type: string
     default: ''
   cosign-key:
     description: "cosign key to sign the image."
-    type: string
     default: ''
   cosign-key-password:
     description: "cosign key password."
-    type: string
     default: ''
   image-labels:
     description: "Image labels."
-    type: string
     required: true
   image-url:
     description: "Image url/name without registry."
-    type: string
     required: true
   image-tags:
     description: "Image tags."
-    type: string
     required: true
-  image-platforms: 
+  image-platforms:
     description: "Image platforms to build for."
-    type: string
     default: linux/amd64
   registry-username:
     description: "Registry username for login."
-    type: string
     required: true
   registry-password:
     description: "Registry password."
-    type: string
     required: true
 
 branding:

--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -2,56 +2,44 @@ name: Container build and push
 description: Generic container build and push action.
 
 inputs:
-  build-context: 
+  build-context:
     description: "Path to image build context. Default: ."
-    type: string
     default: .
   build-docker-file:
     description: "Path to the docker file. Default: ./Dockerfile"
-    type: string
     default: ./Dockerfile
   build-args:
     description: "Use these build-args for the docker build process."
-    type: string
     default: ''
   cosign-key:
     description: "cosign key to sign the image."
-    type: string
     default: ''
   cosign-key-password:
     description: "cosign key password."
-    type: string
     default: ''
   cosign-tlog-upload:
     description: "Turn on or turn off the cosign tlog upload function. Possible options: true/false Default: true"
     default: "true"
   image-labels:
     description: "Image labels."
-    type: string
     required: true
   image-url:
     description: "Image url/name without registry."
-    type: string
     required: true
   image-tags:
     description: "Image tags."
-    type: string
     required: true
-  image-platforms: 
+  image-platforms:
     description: "Image platforms to build for. Default: linux/amd64"
-    type: string
     default: linux/amd64
-  registry: 
+  registry:
     description: "Registry url."
-    type: string
     required: true
-  registry-username: 
+  registry-username:
     description: "Login registry username."
-    type: string
     required: true
-  registry-password: 
+  registry-password:
     description: "Login registry password."
-    type: string
     required: true
 
 branding:

--- a/container-build-push-ghcr/action.yaml
+++ b/container-build-push-ghcr/action.yaml
@@ -2,45 +2,35 @@ name: Container build and push ghcr.io
 description: Container build and push action for ghcr.io.
 
 inputs:
-  build-context: 
+  build-context:
     description: "Path to image build context."
-    type: string
     default: .
   build-docker-file:
     description: "Path to the docker file."
-    type: string
     default: ./Dockerfile
   build-args:
     description: "Use these build-args for the docker build process."
-    type: string
     default: ''
   cosign-key:
     description: "cosign key to sign the image."
-    type: string
     default: ''
   cosign-key-password:
     description: "cosign key password."
-    type: string
     default: ''
   image-labels:
     description: "Image labels."
-    type: string
     required: true
   image-url:
     description: "Image url/name without registry."
-    type: string
     required: true
   image-tags:
     description: "Image tags."
-    type: string
     required: true
-  image-platforms: 
+  image-platforms:
     description: "Image platforms to build for."
-    type: string
     default: linux/amd64
   registry-password:
     description: "Registry password."
-    type: string
     required: true
 
 branding:


### PR DESCRIPTION
## What

Remove input types from container build actions

## Why

There is no input type parameter for actions. It's always string by the way.