### PR TITLE
Try to fix conventional commits for outdated PR branches

### DIFF
--- a/conventional-commits/README.md
+++ b/conventional-commits/README.md
@@ -53,5 +53,5 @@ jobs:
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
 | poetry-version | Poetry version to use for running the action. | Optional (default is latest) |
 | cache-poetry-installation | Cache poetry and its dependencies. | Optional (default is `"true"`) |
-| head-ref | End ref where to look for conventional commits. | Optional (default is`${{ github.event.pull_request.head.sha }}`). |
-| base-ref | Start ref where to look for conventional commits. | Optional (default is `${{ github.event.pull_request.base.sha }}`). |
+| head-ref | End ref where to look for conventional commits. | Optional (default is`${{ github.head_ref }}`). |
+| base-ref | Start ref where to look for conventional commits. | Optional (default is `${{ github.base_ref }}`). |

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -15,11 +15,11 @@ inputs:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"
   head-ref:
-    description: "Use as specific head ref. Defaults to 'github.event.pull_request.head.sha'"
-    default: ${{ github.event.pull_request.head.sha }}
+    description: "Use as specific head ref. Defaults to 'github.head_ref'"
+    default: ${{ github.head_ref }}
   base-ref:
-    description: "Use a specific base ref. Defaults to 'github.event.pull_request.base.sha'."
-    default: ${{ github.event.pull_request.base.sha }}
+    description: "Use a specific base ref. Defaults to 'github.base_ref'."
+    default: ${{ github.base_ref }}
 
 runs:
   using: "composite"
@@ -27,13 +27,11 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        # fetch-depth create a shallow clone https://www.git-scm.com/docs/shallow
-        # with inputs.base-ref as root ref of the repo
-        fetch-depth: 1
+        # fetch all commits of the base-ref. without all commits it's not possible to find the common ancestor
+        fetch-depth: 0
         ref: ${{ inputs.base-ref }}
     - name: Fetch commits
-      # fetch commits from head ref. It stops at base ref because we have a
-      # shallow repo.
+      # fetch commits from head ref
       run: |
         git fetch origin ${{ inputs.head-ref }}
       shell: bash


### PR DESCRIPTION


## What

Try to fix conventional commits for outdated PR branches
## Why

github.event.pull_request.base.sha always points to the latest commit in the target branch. If the target branch and the PR branch diverge git log can't create a "simple" log without having more commits. It requires to find common ancestors. Therefore fetch the full history for now and checkout branch refs instead of the commits.

To be able to only fetch commits required to create the desired log we would need to know the commit ID of the first commit in the PR branch.


