### PR TITLE
Fix creating log for conventional commits

### DIFF
--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -50,8 +50,8 @@ runs:
       run: |
         poetry run conventional-commits \
           --token ${{ inputs.token }} \
-          --base-ref ${{ inputs.base-ref }} \
-          --head-ref ${{ inputs.head-ref }} \
+          --base-ref origin/${{ inputs.base-ref }} \
+          --head-ref origin/${{ inputs.head-ref }} \
           --event-path ${{ github.event_path }} \
           --repository ${{ github.repository }} \
           --working-directory ${{ github.workspace }}


### PR DESCRIPTION


## What
Fix creating log for conventional commits

## Why
For the log it is required to specify the refs with the used remote.