### PR TITLE
Change: Refactor setup-pontos to use pipx action

### DIFF
--- a/admin-bypass/action.yaml
+++ b/admin-bypass/action.yaml
@@ -24,7 +24,6 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python and pontos
-      id: virtualenv
       uses: greenbone/actions/setup-pontos@v3
     - name: allow/not allow bypass?
       run: |
@@ -41,7 +40,6 @@ runs:
       # in case of blubber input let the branch be unlocked!
     - name: Prepare release and store the version
       run: |
-        source ${{ steps.virtualenv.outputs.activate }}
         pontos-github-script pontos.github.scripts.enforce-admins ${{ inputs.repository }} ${{ inputs.branch }} ${{ env.ALLOW_OPT }}
       shell: bash
       env:

--- a/check-version/action.yaml
+++ b/check-version/action.yaml
@@ -20,12 +20,10 @@ runs:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ inputs.python-version }} and pontos
       uses: greenbone/actions/setup-pontos@v3
-      id: virtualenv
       with:
         python-version: ${{ inputs.python-version}}
     - name: Check version information
       run: |
-        source ${{ steps.virtualenv.outputs.activate }}
-        python -m pontos.version verify current
+        pontos-version verify current
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/pipx/README.md
+++ b/pipx/README.md
@@ -43,6 +43,7 @@ jobs:
 |Input Variable|Description| |
 |--------------|-----------|-|
 | python-version | Setup a specific Python version | Optional |
+| python-path | Path to the Python binary to use. Passing python-path allows for setting up a Python version before using this action and running pipx with the set up Python version. | Optional |
 | install | Python application to install | |
 | install-version |  Use a specific version of the application to install. For example '1.2.3'. | Optional |
 | cache | Enable caching for the installed application. | Optional. Disabled by default. `true` to enable. |

--- a/pipx/action.yml
+++ b/pipx/action.yml
@@ -55,7 +55,9 @@ runs:
       shell: bash
     - name: Ensure pipx bin directory is in PATH
       run: |
-        echo "${{ steps.settings.outputs.bin }}" >> $GITHUB_PATH
+        if [[ "$PATH" != *"${{ steps.settings.outputs.bin }}"* ]]; then
+          echo "${{ steps.settings.outputs.bin }}" >> $GITHUB_PATH
+        fi
       shell: bash
     - name: Show current PATH
       run: |

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -151,7 +151,6 @@ runs:
     - name: Create automatic release
       id: release
       run: |
-        source ${{ steps.virtualenv.outputs.activate }}
         pontos-release release ${{ env.ARGS }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       env:

--- a/setup-pontos/README.md
+++ b/setup-pontos/README.md
@@ -24,8 +24,8 @@ jobs:
 |Input Variable|Description| |
 |--------------|-----------|-|
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
-| virtualenv-path |  | Optional (default is `${{ github.workspace }}/pontos-env`) |
-| cache-key | Additional key to use for caching | Optional (default is `pontos-venv`) |
+| virtualenv-path |  | Deprecated and will be ignored. |
+| cache-key |  | Deprecated and will be ignored. |
 
 |Output Variable|Description|
 |---------------|-----------|

--- a/setup-pontos/action.yml
+++ b/setup-pontos/action.yml
@@ -1,16 +1,18 @@
 name: "Setup Pontos Action"
 author: "Björn Ricks <bjoern.ricks@greenbone.net>"
 description: "An action to setup python and pontos"
+
 inputs:
   cache-key:
     description: "Key to use for the cache name."
+    deprecationMessage: "cache-key is deprecated and will be ignored."
     default: "pontos-venv"
   python-version:
     description: "Python version that should be installed and used."
     default: "3.10"
   virtualenv-path:
     description: "Path to the created virtual environment"
-    default: "${{ github.workspace }}/pontos-env"
+    deprecationMessage: "virtualenv-path is deprecated and will be ignored."
 
 outputs:
   virtualenv-path:
@@ -27,36 +29,25 @@ branding:
 runs:
   using: "composite"
   steps:
+    - name: Check if pontos is installed
+      id: pontos
+      run:
+        command -v pontos > /dev/null && echo "installed=true" >> $GITHUB_OUTPUT || echo "installed=false" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Install pontos via pipx
+      id: pipx
+      uses: greenbone/actions/pipx@v3
+      with:
+        python-version: ${{ steps.pontos.outputs.installed == 'false' && inputs.python-version || '' }}
+        install: ${{  steps.pontos.outputs.installed == 'false' && 'pontos' || '' }}
+        cache: "true"
     - name: Virtual Environment
       id: virtualenv
       run: |
-        echo "path=${{ inputs.virtualenv-path }}" >> $GITHUB_OUTPUT
-        echo "activate=${{ inputs.virtualenv-path }}/bin/activate" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Set up Python ${{ inputs.python-version }}
-      id: python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-    - name: Cache Virtual Environment
-      id: cache-virtualenv
-      uses: actions/cache@v3
-      with:
-        key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ inputs.cache-key }}
-        path: ${{ steps.virtualenv.outputs.path }}
-    - name: Create virtual environment
-      if: ${{ steps.cache-virtualenv.outputs.cache-hit != 'true' }}
-      run: |
-        python3 -m venv ${{ steps.virtualenv.outputs.path }}
-      shell: bash
-    - name: Install pontos
-      run: |
-        source ${{ steps.virtualenv.outputs.activate }}
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade pontos
+        echo "path=${{ steps.pipx.outputs.venvs }}/pontos" >> $GITHUB_OUTPUT
+        echo "activate=${{ steps.pipx.outputs.venvs }}/pontos/bin/activate" >> $GITHUB_OUTPUT
       shell: bash
     - name: Print pontos version
       run: |
-        source ${{ steps.virtualenv.outputs.activate }}
         pontos --version
       shell: bash

--- a/sign-release-files/action.yml
+++ b/sign-release-files/action.yml
@@ -83,7 +83,6 @@ runs:
       uses: actions/checkout@v3
     - name: Set up Python and pontos
       uses: greenbone/actions/setup-pontos@v3
-      id: virtualenv
       with:
         python-version: ${{ inputs.python-version }}
     - name: Import gpg key from secrets
@@ -97,7 +96,6 @@ runs:
     - name: Sign files for released version
       run: |
         echo "Signing release files"
-        source ${{ steps.virtualenv.outputs.activate }}
         pontos-release sign ${{ env.ARGS }} --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       if: ${{ inputs.sign-release-files == 'true' }} && ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}


### PR DESCRIPTION
## What

Refactor setup-pontos to use pipx action

## Why
Using the new pipx action heavily simplifies setup-pontos. pipx creates a virtual python environment automatically. The setup-pontos action ensures that pontos is installed only once now too.

## References
DEVOPS-763

Requires self hosted runner having pipx installed.
