### PR TITLE
Conventional commits

### DIFF
--- a/conventional-commits/README.md
+++ b/conventional-commits/README.md
@@ -53,5 +53,5 @@ jobs:
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
 | poetry-version | Poetry version to use for running the action. | Optional (default is latest) |
 | cache-poetry-installation | Cache poetry and its dependencies. | Optional (default is `"true"`) |
-| head-ref | End ref where to look for conventional commits. | Optional (default is`${{ github.head_ref }}`). |
-| base-ref | Start ref where to look for conventional commits. | Optional (default is `${{ github.base_ref }}`). |
+| head-ref | End ref where to look for conventional commits. | Optional (default is`${{ github.event.pull_request.head.sha }}`). |
+| base-ref | Start ref where to look for conventional commits. | Optional (default is `${{ github.event.pull_request.base.sha }}`). |

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -15,11 +15,11 @@ inputs:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"
   head-ref:
-    description: "Use as specific head ref. Defaults to 'github.head_ref'"
-    default: ${{ github.head_ref }}
+    description: "Use as specific head ref. Defaults to 'github.event.pull_request.head.sha'"
+    default: ${{ github.event.pull_request.head.sha }}
   base-ref:
-    description: "Use a specific base ref. Defaults to 'github.base_ref'."
-    default: ${{ github.base_ref }}
+    description: "Use a specific base ref. Defaults to 'github.event.pull_request.base.sha'."
+    default: ${{ github.event.pull_request.base.sha }}
 
 runs:
   using: "composite"

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -24,6 +24,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Refs
+      run: |
+        echo "::debug::ref: ${{ github.ref }}"
+        echo "::debug::ref_name: ${{ github.ref_name }}"
+        echo "::debug::head_ref: ${{ github.head_ref }}"
+        echo "::debug::base_ref: ${{ github.base_ref }}"
+        echo "::debug::pr number: ${{ github.event.pull_request.number }}"
+        echo "::debug::merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}"
+        echo "::debug::PR head ref ${{ github.event.pull_request.head.ref }}"
+        echo "::debug::PR head sha ${{ github.event.pull_request.head.sha }}"
+        echo "::debug::PR base ref ${{ github.event.pull_request.base.ref }}"
+        echo "::debug::PR base sha ${{ github.event.pull_request.base.sha }}"
+      shell: bash
     - name: Checkout repository
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## What

Fix conventional commits for forked PRs again.

## Why

`github.base_ref` contains the branch name in the forked repository. Therefore it can't be used to reference a commit in forked PRs.

## References

https://github.com/greenbone/gsa/actions/runs/5631494476

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


