### PR TITLE
Fix the release

### DIFF
--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -63,8 +63,8 @@ runs:
       run: |
         poetry run conventional-commits \
           --token ${{ inputs.token }} \
-          --base-ref origin/${{ inputs.base-ref }} \
-          --head-ref origin/${{ inputs.head-ref }} \
+          --base-ref ${{ inputs.base-ref }} \
+          --head-ref ${{ inputs.head-ref }} \
           --event-path ${{ github.event_path }} \
           --repository ${{ github.repository }} \
           --working-directory ${{ github.workspace }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -151,6 +151,7 @@ runs:
     - name: Create automatic release
       id: release
       run: |
+        source ${{ steps.virtualenv.outputs.activate }}
         pontos-release release ${{ env.ARGS }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       env:


### PR DESCRIPTION

## What

Fix the next release

## Why

We need a new setup-pontos v3 version before we can run pontos-release without sourcing the venv. Therefore source the venv again for the next release.


## References
https://github.com/greenbone/actions/actions/runs/5643232133/job/15284634964
