### PR TITLE
Fix highlighting users with mattermost-notify

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -62,8 +62,11 @@ runs:
         if [ -n "${{ inputs.workflow-name }}" ]; then
           ARGS="${ARGS} --workflow_name ${{ inputs.workflow-name }}"
         fi
+
+        ARGS="${ARGS} ${{ inputs.MATTERMOST_WEBHOOK_URL }} ${{ inputs.MATTERMOST_CHANNEL }}"
+
         if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" -o -n "${{ inputs.highlight }}" ] ; then
           ARGS="--highlight ${{ inputs.MATTERMOST_HIGHLIGHT }} ${{ inputs.highlight }}"
         fi
 
-        mnotify-git ${ARGS} "${{ inputs.MATTERMOST_WEBHOOK_URL }}" "${{ inputs.MATTERMOST_CHANNEL }}"
+        mnotify-git ${ARGS}


### PR DESCRIPTION


## What

Fix highlighting users with mattermost-notify

## Why

The `--highlight` argument accepts one or more values. Therefore it must be passed after the positionals for the url and channel. Otherwise the values for urls and channels would be considered as additional users to be highlighted.