### PR TITLE
Mattermost notify defaults

### DIFF
--- a/mattermost-notify/README.md
+++ b/mattermost-notify/README.md
@@ -2,7 +2,37 @@
 
 Sends workflow status messages to a Mattermost channel.
 
-## Example
+## Examples
+
+### Usage with job needs
+
+```yml
+name: Some Workflow
+
+on:
+  pull_request:
+
+  jobs:
+    do-something:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do Something
+        run: |
+          echo "I am doing something"
+
+  notify:
+    needs: do-something
+    runs-on: ubuntu-latest
+    steps:
+      - uses: greenbone/actions/mattermost-notify@v3
+        with:
+            url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+            channel: ${{ secrets.MATTERMOST_CHANNEL }}
+            highlight: USER1 USER2
+
+```
+
+### Usage with workflow_run event
 
 - Create a yml file under /.github/workflows.
 - Add under "workflows:" the workflows you want to receive a status message about.
@@ -28,22 +58,25 @@ jobs:
     steps:
       - uses: greenbone/actions/mattermost-notify@v3
         with:
-            MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-            MATTERMOST_CHANNEL: ${{ secrets.MATTERMOST_CHANNEL }}
+            url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+            channel: ${{ secrets.MATTERMOST_CHANNEL }}
             highlight: USER1 USER2
 ```
+
 
 ## Action Configuration
 
 |Input Variable|Description| |
 |--------------|-----------|-|
-| MATTERMOST_WEBHOOK_URL | Mattermost webhook url | Required |
-| MATTERMOST_CHANNEL | Mattermost channel | Required |
+| url | Mattermost webhook url | Required. |
+| channel | Mattermost channel to post message in. | Required. |
+| highlight | List of space separated users to highlight in the channel | Optional. |
+| branch | Git branch to use in the message | Optional. Default is `${{ github.ref_name }}`. Will be derived from the event if empty. |
+| commit | Git commit to use in the message | Optional. Default is `${{ github.sha }}`. Will be derived from the event if empty. |
+| commit-message | Git commit message to use in the message | Optional. Will be derived from the event if commit is empty. Otherwise it will be derived from the git log. |
+| repository | GitHub repository (org/repo) | Optional. Default is `${{ github.repository }}`. |
+| workflow | GitHub workflow ID to use in the message | Optional. Default is `${{ github.run_id }}`. |
+| workflow-name | GitHub workflow name to use in the message | Optional. Default is `${{ github.workflow }}` |
+| MATTERMOST_WEBHOOK_URL | Mattermost webhook url | Deprecated. Use url instead. |
+| MATTERMOST_CHANNEL | Mattermost channel | Deprecated. Use channel instead. |
 | MATTERMOST_HIGHLIGHT | List of space separated users to highlight in the channel | Deprecated. Use highlight instead |
-| highlight | List of space separated users to highlight in the channel | Optional |
-| branch | Git branch to use in the message | Optional. Will be derived from the event if not set. |
-| commit | Git commit to use in the message | Optional. Will be derived from the event if not set. |
-| commit-message | Git commit message to use in the message | Optional. Will be derived from the event if commit is not set. Otherwise it will be derived from the git log. |
-| repository | GitHub repository (org/repo) | Optional. Default is `${{ github.repository }}` |
-| workflow | GitHub workflow ID to use in the message | Optional |
-| workflow-name | GitHub workflow name to use in the message | Optional |

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -18,18 +18,22 @@ inputs:
   highlight:
     description: "highlight users in channel"
   branch:
-    description: Git branch
+    description: Git branch. Default is 'github.ref_name'.
+    default: ${{ github.ref_name }}
   commit:
-    description: Git commit
+    description: Git commit. Default is 'github.sha'.
+    default: ${{ github.sha }}
   commit-message:
     description: Git commit message to use
   repository:
-    description: GitHub repository (org/repo). Default is github.repository
+    description: GitHub repository (org/repo). Default is 'github.repository'
     default: ${{ github.repository }}
   workflow:
-    description: GitHub workflow ID
+    description: GitHub workflow ID. Default is 'github.run_id'.
+    default: ${{ github.run_id }}
   workflow-name:
-    description: GitHub workflow name
+    description: GitHub workflow name. Default is 'github.workflow'
+    default: ${{ github.workflow }}
 
 branding:
   icon: "package"

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -42,6 +42,13 @@ branding:
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      # we need a checkout to determine the commit-message per git
+      # if commit is set but commit-message is not
+      if: inputs.commit && !inputs.commit-message
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.commit }}
     - name: Install
       uses: greenbone/actions/pipx@v3
       id: pipx


### PR DESCRIPTION
## What

Adjust mattermost-notify action to use sane defaults for all use cases

## Why

It wont be used for workflow_run events as main use case anymore. Therefore use defaults that fit for all kind of events.
