### PR TITLE
Fix: Quote input arguments for mattermost-notify

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -60,28 +60,28 @@ runs:
       run: |
         ARGS=""
         if [ -n "${{ inputs.commit }}" ]; then
-          ARGS="${ARGS} --commit ${{ inputs.commit }}"
+          ARGS="${ARGS} --commit \"${{ inputs.commit }}\""
         fi
         if [ -n "${{ inputs.commit-message }}" ]; then
-          ARGS="${ARGS} --commit-message ${{ inputs.commit-message }}"
+          ARGS="${ARGS} --commit-message \"${{ inputs.commit-message }}\""
         fi
         if [ -n "${{ inputs.branch }}" ]; then
-          ARGS="${ARGS} --branch ${{ inputs.branch }}"
+          ARGS="${ARGS} --branch \"${{ inputs.branch }}\""
         fi
         if [ -n "${{ inputs.repository }}" ]; then
-          ARGS="${ARGS} --repository ${{ inputs.repository }}"
+          ARGS="${ARGS} --repository \"${{ inputs.repository }}\""
         fi
         if [ -n "${{ inputs.workflow }}" ]; then
-          ARGS="${ARGS} --workflow ${{ inputs.workflow }}"
+          ARGS="${ARGS} --workflow \"${{ inputs.workflow }}\""
         fi
         if [ -n "${{ inputs.workflow-name }}" ]; then
-          ARGS="${ARGS} --workflow_name ${{ inputs.workflow-name }}"
+          ARGS="${ARGS} --workflow_name \"${{ inputs.workflow-name }}\""
         fi
 
-        ARGS="${ARGS} ${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }} ${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}"
+        ARGS="${ARGS} \"${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }}\" \"${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}\""
 
         if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" -o -n "${{ inputs.highlight }}" ] ; then
-          ARGS="${ARGS} --highlight ${{ inputs.MATTERMOST_HIGHLIGHT }} ${{ inputs.highlight }}"
+          ARGS="${ARGS} --highlight \"${{ inputs.MATTERMOST_HIGHLIGHT }}\" \"${{ inputs.highlight }}\""
         fi
 
         mnotify-git ${ARGS}


### PR DESCRIPTION


## What
Quote input arguments for mattermost-notify

## Why


The input argument values may contain spaces and then they are considered as the next argument instead of value. Therefore quote all input argument values. This will ensure that they are parsed as argument values.
