### PR TITLE
Fix: Disable caching of poetry in coverage-python action

### DIFF
--- a/coverage-python/README.md
+++ b/coverage-python/README.md
@@ -27,9 +27,9 @@ jobs:
 | python-version | Python version that should be installed | Optional (default: "3.10") |
 | test-command | Command to run the unit tests | Optional (default: `"-m unittest"`)
 | poetry-version | Use a specific poetry version. By default the latest release is used. | Optional |
-| cache | Cache dependencies by setting it to `"true"`. Leave unset or set to an other string then `"true"` to disable the cache. | Optional |
+| cache | Cache dependencies by setting it to `"true"`. | Optional |
 | cache-dependency-path | "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies. | Optional |
-| cache-poetry-installation | Cache poetry and its dependencies. Default is `"true"`. Set to an other string then `"true"` to disable the cache. | Optional (default is `"true"`) |
+| cache-poetry-installation | Cache poetry and its dependencies by setting it to `"true"`. | Optional |
 | install-dependencies | Install project dependencies. Default is `"true"`. Set to an other string then `"true"` to not install the dependencies. | Optional (default: `"true"`) |
 | working-directory | Working directory where to run the action | Optional (default is `${{ github.workspace }}`) |
 | codecov-upload | "Upload coverage to codecov.io. Default is `"true"`. Set to an other string then `"true"` to disable the upload. | Optional (default: `"true"`)

--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -15,12 +15,11 @@ inputs:
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
   cache:
-    description: "Cache dependencies by setting it to 'true'. Leave unset or set to an other string then 'true' to disable the cache."
+    description: "Cache dependencies by setting it to 'true'."
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
   cache-poetry-installation:
-    description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
-    default: "true"
+    description: "Cache poetry and its dependencies by setting it to 'true'."
   install-dependencies:
     description: "Install project dependencies. Default is 'true'. Set to an other string then 'true' to not install the dependencies."
     default: "true"


### PR DESCRIPTION


## What

Disable caching of poetry in coverage-python action

## Why
The caching is currently broken and therefore should be deactivated.

## References

https://github.com/greenbone/autohooks-plugin-pylint/actions/runs/5710696688/job/15667895141#step:11:32


