### PR TITLE
Fix: Don't try to adjust admin bypass when branch is not `main`

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -141,6 +141,7 @@ runs:
 
       # Enable admin bypass
     - name: Allow admin users bypassing protection on ${{ inputs.ref}} branch
+      if: inputs.ref == 'main'
       uses: greenbone/actions/admin-bypass@v3
       with:
         allow: "true"
@@ -160,7 +161,7 @@ runs:
 
       # Disable admin bypass
     - name: Disable bypassing protection on ${{ inputs.ref}} branch for admin users
-      if: always()
+      if: inputs.ref == 'main' && always()
       uses: greenbone/actions/admin-bypass@v3
       with:
         allow: "false"


### PR DESCRIPTION
## What
Don't try to adjust admin bypass when branch is not `main`

Iff we need other branches, we should think about adding them, too!
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

When trying to release from a tag, this doesn't work