### PR TITLE
Fix: highlight in mattermost-notify

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -95,7 +95,7 @@ runs:
         if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" ] || [ -n "${{ inputs.highlight }}" ]; then
           ARGS+=(--highlight)
           # Add every highlight element as its own string
-          IFS=' ' read -ra HIGHLIGHTS <<< "${{ inputs.MATTERMOST_HIGHLIGHT }}" ${{ inputs.highlight }}"
+          IFS=' ' read -ra HIGHLIGHTS <<< "${{ inputs.MATTERMOST_HIGHLIGHT }} ${{ inputs.highlight }}"
           for HIGHLIGHT in "${HIGHLIGHTS[@]}"; do
             ARGS+=("$HIGHLIGHT")
           done

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -92,8 +92,13 @@ runs:
 
         ARGS+=("${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }}" "${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}")
 
-        if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" -o -n "${{ inputs.highlight }}" ]; then
-          ARGS+=(--highlight "${{ inputs.MATTERMOST_HIGHLIGHT }}" "${{ inputs.highlight }}")
+        if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" ] || [ -n "${{ inputs.highlight }}" ]; then
+          ARGS+=(--highlight)
+          # Add every highlight element as its own string
+          IFS=' ' read -ra HIGHLIGHTS <<< "${{ inputs.MATTERMOST_HIGHLIGHT }}" ${{ inputs.highlight }}"
+          for HIGHLIGHT in "${HIGHLIGHTS[@]}"; do
+            ARGS+=("$HIGHLIGHT")
+          done
         fi
 
         mnotify-git "${ARGS[@]}"


### PR DESCRIPTION
## What
Fix: highlight in mattermost-notify
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

<!-- Describe why are these changes necessary? -->
The mattermost-notify service needs highlights as single arguments.
## References
None
<!-- Add identifier for issue tickets, links to other PRs, etc. -->



