### PR TITLE
New release options

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -39,34 +39,36 @@ You can alternatively set an explicit `release-version`. It will overwrite the `
 
 ## Input arguments
 
-| Argument             | Description                                                                                                                     | Required? |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------------|-----------|
-| conventional-commits | Deprecated                                                                                                                      | Optional  |
-| git-tag-prefix      | Set git tag prefix to the passed input. Default: 'v'                                                                             | Optional (default is `v`) |
-| github-user          | Github user name on behalf of whom the actions will be executed.                                                                | Yes       |
-| github-user-mail     | Mail address for the given github user.                                                                                         | Yes       |
-| github-user-token    | Token with write rights required to create the release.                                                                         | Yes       |
-| gpg-fingerprint      | GPG fingerprint, represented as a string. Required for signing assets of the release.                                           | Optional  |
-| gpg-key              | GPG key, represented as a string. Required for signing assets of the release.                                                   | Optional  |
-| gpg-passphrase       | GPG passphrase, represented as a string. Required for signing assets of the release.                                            | Optional  |
-| strategy             | Deprecated by `release-type`.                                                                                                   | Optional  |
-| python-version       | Python version used to create the release. (Only important for python projects)                                                 | Optional (default `"3.10"` ) |
-| ref                  | This branch's/tag's HEAD will be candidate of the next release.                                                                 | Optional (default: `main`) |
-| release-type         | What type of release should be executed? Supported: `alpha`, `beta`, `calendar`, `major`, `minor`, `patch`, `release-candidate` | Optional (default: `patch`) |
-| release-version      | Set an explicit version, that should be released.                                                                               | Optional  |
-| release-series  | Allow to determine release versions for an older release series like '22.4'. | Optional | None |
-| versioning-scheme    | What versioning scheme should be used for the release? Supported: `semver`, `pep440`                                            | Optional (default: `pep440` ) |
-| sign-release-files | Create and upload release file signatures. Default is 'true'. Set to an other string then 'true' to disable the signatures. | Optional (default `"true"`) |
-| update-project | Update version in project files like `pyproject.toml`. Default is 'true'. Set to an other string then 'true' to disable updating project files. |  Optional (default `"true"`) |
+| Argument             | Description                                                                                                                                                                               | Required?                     |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| conventional-commits | Deprecated                                                                                                                                                                                | Optional                      |
+| git-tag-prefix       | Set git tag prefix to the passed input. Default: 'v'                                                                                                                                      | Optional (default is `v`)     |
+| github-user          | Github user name on behalf of whom the actions will be executed.                                                                                                                          | Yes                           |
+| github-user-mail     | Mail address for the given github user.                                                                                                                                                   | Yes                           |
+| github-user-token    | Token with write rights required to create the release.                                                                                                                                   | Yes                           |
+| gpg-fingerprint      | GPG fingerprint, represented as a string. Required for signing assets of the release.                                                                                                     | Optional                      |
+| gpg-key              | GPG key, represented as a string. Required for signing assets of the release.                                                                                                             | Optional                      |
+| gpg-passphrase       | GPG passphrase, represented as a string. Required for signing assets of the release.                                                                                                      | Optional                      |
+| strategy             | Deprecated by `release-type`.                                                                                                                                                             | Optional                      |
+| python-version       | Python version used to create the release. (Only important for python projects)                                                                                                           | Optional (default `"3.10"` )  |
+| ref                  | This branch's/tag's HEAD will be candidate of the next release.                                                                                                                           | Optional (default: `main`)    |
+| release-type         | What type of release should be executed? Supported: `alpha`, `beta`, `calendar`, `major`, `minor`, `patch`, `release-candidate`                                                           | Optional (default: `patch`)   |
+| release-version      | Set an explicit version, that should be released.                                                                                                                                         | Optional                      |
+| release-series       | Allow to determine release versions for an older release series like '22.4'.                                                                                                              | Optional                      | None |
+| versioning-scheme    | What versioning scheme should be used for the release? Supported: `semver`, `pep440`                                                                                                      | Optional (default: `pep440` ) |
+| sign-release-files   | Create and upload release file signatures. Default is 'true'. Set to an other string then 'true' to disable the signatures.                                                               | Optional (default `"true"`)   |
+| update-project       | Update version in project files like `pyproject.toml`. Default is 'true'. Set to an other string then 'true' to disable updating project files.                                           | Optional (default `"true"`)   |
+| next-version         | Set an explicit version that should be used after the release. Leave empty for determining the next version automatically. Set to `'false'` for not updating the version after a release. |                               |
+| github-pre-release   | Set to `'true'`` to enforce uploading the release to GitHub as a pre-release                                                                                                              |                               |
 
 ## Output Arguments
 
-|Output Variable|Description|
-|---------------|-----------|
+| Output Variable      | Description                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------- |
 | release-version      | Version of the release. Depending on the inputs it is calculated from the detected last release version. |
-| last-release-version | Detected version of the previous release. |
-| git-release-tag      | Git tag created for the release version |
-| next-version         | Version set after a successful release |
+| last-release-version | Detected version of the previous release.                                                                |
+| git-release-tag      | Git tag created for the release version                                                                  |
+| next-version         | Version set after a successful release                                                                   |
 
 
 ## Examples

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -79,6 +79,8 @@ runs:
     - name: Checkout exists already
       id: checkout
       run: |
+        echo "Check for existing repository checkout"
+
         if [[ -d "${{ github.workspace }}/.git" ]]; then
           echo "exists=true" >> $GITHUB_OUTPUT
         else
@@ -106,6 +108,8 @@ runs:
       # Input parsing
     - name: Parse release-type
       run: |
+        echo "Determine release type"
+
         case ${{ inputs.release-type }} in
           alpha | beta | calendar | major | minor | patch | release-candidate)
             ARGS="--release-type ${{ inputs.release-type }}"

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -53,6 +53,12 @@ inputs:
   update-project:
     description: "Update version in project files like `pyproject.toml`. Default is 'true'. Set to an other string then 'true' to disable updating project files."
     default: "true"
+  next-version:
+    description: |
+      "Set an explicit version that should be used after the release. Leave empty for determining the next version automatically. Set to 'false' for not updating "
+      "the version after a release."
+  github-pre-release:
+    description: "Set to 'true' to enforce uploading the release to GitHub as a pre-release"
 
 outputs:
   release-version:
@@ -142,6 +148,22 @@ runs:
         ARGS="${ARGS} --no-update-project"
         echo "ARGS=${ARGS}" >> $GITHUB_ENV
       shell: bash
+    - name: Determine next version
+      if: ${{ inputs.next-version }}
+      run: |
+        if [[ "${{ inputs.next-version }}" = "false" ]]; then
+          ARGS="${ARGS} --no-next-version"
+        else
+          ARGS="${ARGS} --next-version ${{ inputs.next-version }}"
+        fi
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
+    - name: Enforce pre-release"
+      if: ${{ inputs.pre-release == 'true' }}
+      run: |
+        ARGS="${ARGS} --github-pre-release"
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
 
       # Enable admin bypass
     - name: Allow admin users bypassing protection on ${{ inputs.ref}} branch
@@ -177,7 +199,7 @@ runs:
       if: inputs.sign-release-files == 'true' && inputs.gpg-key && inputs.gpg-fingerprint && inputs.gpg-passphrase
       with:
         python-version: ${{ inputs.python-version }}
-        git-tag-prefix:  ${{ inputs.git-tag-prefix }}
+        git-tag-prefix: ${{ inputs.git-tag-prefix }}
         github-token: ${{ inputs.github-user-token }}
         gpg-fingerprint: ${{ inputs.gpg-fingerprint }}
         gpg-passphrase: ${{ inputs.gpg-passphrase }}


### PR DESCRIPTION
## What

Add new arguments for release workflow
* next-version - to set an explicit version after a release or to completely deactivate a version update after a release
* github-pre-release - to enforce uploading a release as a pre-release to GitHub

## Why

Support new release workflows.

## References

DEVOPS-828
DEVOPS-826

