### PR TITLE
Fix: Use correct input variable to enforce creating a GitHub pre-release

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -159,7 +159,7 @@ runs:
         echo "ARGS=${ARGS}" >> $GITHUB_ENV
       shell: bash
     - name: Enforce pre-release"
-      if: ${{ inputs.pre-release == 'true' }}
+      if: ${{ inputs.github-pre-release == 'true' }}
       run: |
         ARGS="${ARGS} --github-pre-release"
         echo "ARGS=${ARGS}" >> $GITHUB_ENV


### PR DESCRIPTION


## What

Use correct input variable to enforce creating a GitHub pre-release

## Why
The input variable is named github-pre-release and not pre-release.

## References

DEVOPS-826
