### PR TITLE
Change: keep previous PR comments from SBOM scan in container-build-push-generic

### DIFF
--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -124,6 +124,7 @@ runs:
         dockerhub-user: ${{ inputs.scout-user }}
         dockerhub-password: ${{ inputs.scout-password }}
         sarif-file: /tmp/${{ steps.image.outputs.name }}.sarif
+        keep-previous-comments: true
 
     - name: Upload sbom sarif file
       if: ${{ github.event_name == 'pull_request' && inputs.scout-user && inputs.scout-password }}


### PR DESCRIPTION
## What
Change: keep previous PR comments from SBOM scan in container-build-push-generic
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Since we have several images in some repositoies, we have to keep all the comments, otherwise they will be replaced
<!-- Describe why are these changes necessary? -->

## References
None



