### PR TITLE
Add: Allow Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -42,4 +42,6 @@ runs:
           MIT OR Apache-2.0,
           MIT AND Python-2.0,
           (Apache-2.0 AND BSD-3-Clause) OR (Apache-2.0 AND MIT),
-          (MIT OR Apache-2.0) AND Unicode-DFS-2016
+          (MIT OR Apache-2.0) AND Unicode-DFS-2016,
+          OFL-1.1,
+          Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1


### PR DESCRIPTION
## What

Allow Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1

## Why

Used by [pheme](https://github.com/greenbone/pheme) dependency [fonttools](https://github.com/fonttools/fonttools).

Marked as an incompatible license: https://github.com/greenbone/pheme/actions/runs/6611060691

