### PR TITLE
Change: Remove build step from test-node action

### DIFF
--- a/test-node/action.yaml
+++ b/test-node/action.yaml
@@ -37,14 +37,6 @@ runs:
         token: ${{ inputs.token }}
         dependency-manager: ${{ inputs.dependency-manager }}
         registry-url: ${{ inputs.registry-url }}
-    - name: Build with npm
-      if: ${{ inputs.dependency-manager == 'npm' }}
-      run: npm run build
-      shell: bash
-    - name: Build with yarn
-      if: ${{ inputs.dependency-manager == 'yarn' }}
-      run: yarn build
-      shell: bash
     - name: Run Tests
       if: ${{ inputs.dependency-manager == 'npm' }}
       run: npm run test:ci


### PR DESCRIPTION
## What

Remove build step from test-node action

## Why

Testing npm projects do not require them to be build beforehand. The node test-frameworks build the code itself.
