### PR TITLE
Change: README typo setup-github-user to set-github-user

### DIFF
--- a/set-github-user/README.md
+++ b/set-github-user/README.md
@@ -16,7 +16,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     steps:
-        - uses: greenbone/actions/setup-github-user@v3
+        - uses: greenbone/actions/set-github-user@v3
           with:
             user: ${{ vars.user }}
             mail: ${{ vars.mail }}


### PR DESCRIPTION
## What

Hotfix : readme typo setup-github-user to set-github-user

## Why

Typo setup-github-user to set-github-user

## References

N/A




