### PR TITLE
Put gpg fingerprint in vars

### DIFF
--- a/.github/workflows/test-signature.yml
+++ b/.github/workflows/test-signature.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test-creating-signature-file:
@@ -20,7 +21,7 @@ jobs:
         with:
           gpg-key: ${{ secrets.TEST_GPG_KEY }}
           gpg-passphrase: ${{ secrets.TEST_GPG_PASSPHRASE }}
-          gpg-fingerprint: ${{ secrets.TEST_GPG_FINGERPRINT }}
+          gpg-fingerprint: ${{ vars.TEST_GPG_FINGERPRINT }}
           file: ./signature/action.yml
           signature-file: test.asc
       - name: Check the signature
@@ -31,7 +32,7 @@ jobs:
         with:
           gpg-key: ${{ secrets.TEST_GPG_KEY }}
           gpg-passphrase: ${{ secrets.TEST_GPG_PASSPHRASE }}
-          gpg-fingerprint: ${{ secrets.TEST_GPG_FINGERPRINT }}
+          gpg-fingerprint: ${{ vars.TEST_GPG_FINGERPRINT }}
           file: ./signature/action.yml
       - name: Check the signature
         run: |

--- a/signature/action.yml
+++ b/signature/action.yml
@@ -29,13 +29,13 @@ runs:
       shell: bash
       run: |
         echo -e "${{ inputs.gpg-key }}" >> tmp.file
-        gpg --pinentry-mode loopback --passphrase ${{ inputs.gpg-passphrase }} --import tmp.file
+        gpg --pinentry-mode loopback --passphrase '${{ inputs.gpg-passphrase }}' --import tmp.file
         rm tmp.file
     - name: "Create a GPG signature"
       shell: bash
       run: |
         if [ -z "${{ inputs.signature-file }}"]; then
-          gpg --pinentry-mode loopback --local-user ${{ inputs.gpg-fingerprint }} --yes --detach-sign --passphrase ${{ inputs.gpg-passphrase }} --armor ${{ inputs.file }}
+          gpg --pinentry-mode loopback --local-user '${{ inputs.gpg-fingerprint }}' --yes --detach-sign --passphrase '${{ inputs.gpg-passphrase }}' --armor '${{ inputs.file }}'
         else
-          gpg --pinentry-mode loopback --local-user ${{ inputs.gpg-fingerprint }} --yes --detach-sign --passphrase ${{ inputs.gpg-passphrase }} --armor --output ${{ inputs.signature-file }} ${{ inputs.file }}
+          gpg --pinentry-mode loopback --local-user '${{ inputs.gpg-fingerprint }}' --yes --detach-sign --passphrase '${{ inputs.gpg-passphrase }}' --armor --output ${{ inputs.signature-file }} '${{ inputs.file }}'
         fi


### PR DESCRIPTION

## What
Put gpg fingerprint in vars and allow for password with special characters like `$`

## Why
The gpg fingerprint of the signature action testing key doesn't need to be a secret.
Creating signatures shouldn't fail with special characters in user input.

## References

DEVOPS-903
