### PR TITLE
Fix is latest tag

### DIFF
--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         if [ "${{ github.ref_type }}" = "tag" ]; then
           # find the latest version that is not ourself
-          export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort)
+          export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort | head -n 1)
 
           # get major minor patch versions
           IFS='.' read -r latest_major latest_minor latest_patch << EOF

--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -34,8 +34,11 @@ runs:
           latest_major=$(echo $latest_major | cut -c2-)
           tag_major=$(echo $tag_major | cut -c2-)
 
-          echo "$tag_major >= $latest_major"
-          if [[ $tag_major -ge $latest_major && ($tag_minor -ne 0 || $tag_patch -ne 0) ]]; then
+          if [[ $tag_major -gt $latest_major ]];
+            echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+          elif [[ $tag_major -eq $latest_major && $tag_minor -gt $latest_minor ]]; then
+            echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+          elif [[ $tag_major -eq $latest_major && $tag_minor -eq $latest_minor && $tag_patch -gt $latest_patch ]]; then
             echo "is-latest-tag=true" >> $GITHUB_OUTPUT
           else
             echo "is-latest-tag=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Not sure what the previous check was about. Now it is the latest version
1. if the major version is greater
2. if the major versions are equal and the minor version is greater
3. if the major and minor versions are equal and if the patch version is
   greater


## Why

It didn't consider the 23.0.0 release of GSA as latest tag.