### PR TITLE
Fix: Fix typo in if-condition

### DIFF
--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -34,7 +34,7 @@ runs:
           latest_major=$(echo $latest_major | cut -c2-)
           tag_major=$(echo $tag_major | cut -c2-)
 
-          if [[ $tag_major -gt $latest_major ]];
+          if [[ $tag_major -gt $latest_major ]]; then
             echo "is-latest-tag=true" >> $GITHUB_OUTPUT
           elif [[ $tag_major -eq $latest_major && $tag_minor -gt $latest_minor ]]; then
             echo "is-latest-tag=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What
Fix typo in if-condition

## Why
Failing CI checks:

```
Run greenbone/actions/is-latest-tag@v3
Run if [ "branch" = "tag" ]; then
/home/runner/work/_temp/b7cf2293-d120-457c-be78-971c55f23833.sh: line 20: syntax error near unexpected token `elif'
Error: Process completed with exit code 2.
```

