### PR TITLE
Change: Support trusted publishing via OICD on PyPI

### DIFF
--- a/pypi-upload/README.md
+++ b/pypi-upload/README.md
@@ -2,7 +2,9 @@
 
 Action to build a Python distributable via Poetry and upload it to [PyPI](https://pypi.org)
 
-## Example
+## Example 1
+
+Use a token for uploading the package to PyPI.
 
 ```yaml
 name: Deploy on PyPI
@@ -21,10 +23,35 @@ jobs:
           pypi-token: ${{ secrets.PYPI_TOKEN }}
 ```
 
+## Example 1
+
+Use [trusted publisher](https://docs.pypi.org/trusted-publishers/) for uploading
+the package to PyPI. The trusted publisher mechanism uses OpenID Connect (OIDC)
+to issue short term tokens. This requires `write` permissions for `id-token`.
+
+```yaml
+name: Deploy on PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Build and publish to PyPI
+        uses: greenbone/actions/pypi-upload@v3
+        with:
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+```
+
 ## Action Configuration
 
-| Input | Description | |
-|-------|-------------|-|
-| pypi-token | Token for uploading the build to PyPI | Required |
-| python-version | Python version to use for this action | Optional (default: "3.10") |
-| ref | The branch, tag or SHA to checkout. | Optional (default depends on the [event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)) |
+| Input          | Description                           |                                                                                                                             |
+| -------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| pypi-token     | Token for uploading the build to PyPI | Optional. If not provided [trusted publisher](https://docs.pypi.org/trusted-publishers/) will be used.                      |
+| python-version | Python version to use for this action | Optional (default: "3.10")                                                                                                  |
+| ref            | The branch, tag or SHA to checkout.   | Optional (default depends on the [event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)) |

--- a/pypi-upload/action.yaml
+++ b/pypi-upload/action.yaml
@@ -8,7 +8,7 @@ inputs:
     default: "3.10"
   pypi-token:
     description: "Token for uploading the build to PyPI"
-    required: true
+    required: false
   ref:
     description: The branch, tag or SHA to checkout. Default depends on the event (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows).
 
@@ -32,10 +32,11 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade poetry
       shell: bash
-    - name: Build and publish
+    - name: Build
       run: |
         poetry build
-        poetry publish
       shell: bash
-      env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ inputs.pypi-token }}
+    - name: Upload
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ inputs.pypi-token }}


### PR DESCRIPTION


## What

Support trusted publishing via OICD on PyPI

## Why
Use pypa/gh-action-pypi-publish action to upload packages to PyPI which uses trusted publishing via OpenID Connect (OICD) when not passing a token as password.

## References

DEVOPS-931
