### PR TITLE
Change: Use GitHub environment for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
   release:
     name: Actions
     runs-on: 'ubuntu-latest'
+    environment:
+      name: release
+      url: https://github.com/greenbone/actions/releases
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION


## What

Use GitHub environment for releases
## Why

This allows for showing a progress bar during the workflow run and also most important to secure the workflow even more. For example an environment can restrict the branch from where is workflow may be run.