### PR TITLE
Setup python v5

### DIFF
--- a/pipx/action.yml
+++ b/pipx/action.yml
@@ -87,7 +87,7 @@ runs:
       # cache venv only if an application will be installed and the user requested caching and no python path is set
       if: inputs.install && inputs.cache == 'true' && !inputs.python-path
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.settings.outputs.venvs }}/${{ inputs.install }}
         key: python-${{ steps.python.outputs.python-version }}-pipx-venv-${{ inputs.install }}-${{ inputs.install-version || 'latest' }}

--- a/pipx/action.yml
+++ b/pipx/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Setup Python
       if: inputs.python-version
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       id: python
       with:
         python-version: ${{ inputs.python-version }}

--- a/pypi-upload/action.yaml
+++ b/pypi-upload/action.yaml
@@ -24,7 +24,7 @@ runs:
       with:
         ref: ${{ inputs.ref }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install pip and poetry


### PR DESCRIPTION
## What

Update actions/setup-python and actions/cache to the latest major releases.

## Why

Fix deprecation warning `Node.js 16 actions are deprecated`

## References

https://github.com/greenbone/actions/actions/runs/7654546686

