### PR TITLE
Change: Update actions/checkout v3 to v4

### DIFF
--- a/check-version/action.yaml
+++ b/check-version/action.yaml
@@ -17,7 +17,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ inputs.python-version }} and pontos
       uses: greenbone/actions/setup-pontos@v3
       with:

--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -102,7 +102,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: "Checkout Repository"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Dependency Review"
       uses: actions/dependency-review-action@v3
       with:

--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: "Checkout Repository"
       uses: actions/checkout@v4
     - name: "Dependency Review"
-      uses: actions/dependency-review-action@v3
+      uses: actions/dependency-review-action@v4
       with:
         fail-on-severity: high
         vulnerability-check: true

--- a/doc-coverage-clang/action.yml
+++ b/doc-coverage-clang/action.yml
@@ -1,6 +1,6 @@
-name: 'Build XML documentation and upload coverage'
+name: "Build XML documentation and upload coverage"
 author: "Jaspar Stach <jaspar.stach@greenbone.net>"
-description: 'An action to upload documentation coverage to codecov.io for C Lang repository. Requires to run with the greenbone/doxygen docker image.'
+description: "An action to upload documentation coverage to codecov.io for C Lang repository. Requires to run with the greenbone/doxygen docker image."
 branding:
   icon: "package"
   color: "green"
@@ -12,10 +12,10 @@ runs:
     - name: Install coverxygen and codecov
       shell: bash
       run: |
-          python3 -m venv .venv
-          . .venv/bin/activate
-          pip install setuptools --upgrade
-          pip install 'coverxygen>=1.3.1' codecov
+        python3 -m venv .venv
+        . .venv/bin/activate
+        pip install setuptools --upgrade
+        pip install 'coverxygen>=1.3.1' codecov
     - name: Generate documentation (XML)
       shell: bash
       run: |
@@ -26,9 +26,9 @@ runs:
     - name: Establish documentation coverage
       shell: bash
       run: |
-          . .venv/bin/activate
-          python -m coverxygen --src-dir ${{ github.workspace }} \
-          --xml-dir build/doc/generated/xml/ --output lcov.info
+        . .venv/bin/activate
+        python -m coverxygen --src-dir ${{ github.workspace }} \
+        --xml-dir build/doc/generated/xml/ --output lcov.info
     - name: Upload documentation coverage to codecov
       uses: codecov/codecov-action@v1
       with:

--- a/doc-coverage-clang/action.yml
+++ b/doc-coverage-clang/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install coverxygen and codecov
       shell: bash
       run: |

--- a/helm-build-push/README.md
+++ b/helm-build-push/README.md
@@ -22,7 +22,7 @@ jobs:
 ## Action Configuration
 
 | Input Variable          | Description                                                                     |          |
-|-------------------------|---------------------------------------------------------------------------------|----------|
+| ----------------------- | ------------------------------------------------------------------------------- | -------- |
 | charts-path             | Path to charts base folder. Default: ./charts                                   | Optional |
 | chart-name              | Chart to build and push.                                                        | Required |
 | registry                | registry name. Default: ghcr.io                                                 | Optional |
@@ -36,7 +36,7 @@ jobs:
 
 ## Action Output
 
-|Output Variable|Description|
-|--------------|-----------|
-| tag | Helm chart url's with tag |
-| digest | The helm chart digest |
+| Output Variable | Description               |
+| --------------- | ------------------------- |
+| tag             | Helm chart url's with tag |
+| digest          | The helm chart digest     |

--- a/helm-build-push/README.md
+++ b/helm-build-push/README.md
@@ -10,7 +10,7 @@ jobs:
     name: Build and push helm chart
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build and push chart
         uses: greenbone/actions/helm-build-push@v3
         with:

--- a/helm-version-upgrade/README.md
+++ b/helm-version-upgrade/README.md
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: run helm-version-upgrade
         uses: greenbone/actions/helm-version-upgrade@v3
         with:

--- a/helm-version-upgrade/README.md
+++ b/helm-version-upgrade/README.md
@@ -24,17 +24,17 @@ jobs:
 ```
 ## Action Configuration
 
-| Input Variable                 | Description                                                     | Required / Optional      |
-| -------------------------------| --------------------------------------------------------------- | ------------------------ |
-| chart-path                     | Full path to helm chart folder                                  | Required                 |
-| chart-version                  | New helm chart version                                          | Optional                 |
-| chart-version-increase         | Increase helm chart patch level version                         | Optional                 |
-| app-version                    | New helm chart appVersion, optional default chart-version       | Optional                 |
-| image-tag                      | New helm chart docker image tag, optional default chart-version | Optional                 |
-| overwrite-parent-key-image-tag | Overwrite parent image key name, optional default empty         | Optional                 |
-| no-tag                         | Do not upgrade an image tag in values                           | Optional                 |
-| dependency-version             | New helm chart dependency version                               | Optional                 |
-| dependency-name                | Helm chart dependency to upgrade                                | Optional                 |
-| git-user                       | Git user name for commit, set only if autocommit is desired     | Optional                 |
-| git-user-email                 | Git user email for commit, set only if autocommit is desired    | Optional                 |
-| token                          | Github token for commit, set only if autocommit is desired      | Optional                 |
+| Input Variable                 | Description                                                     | Required / Optional |
+| ------------------------------ | --------------------------------------------------------------- | ------------------- |
+| chart-path                     | Full path to helm chart folder                                  | Required            |
+| chart-version                  | New helm chart version                                          | Optional            |
+| chart-version-increase         | Increase helm chart patch level version                         | Optional            |
+| app-version                    | New helm chart appVersion, optional default chart-version       | Optional            |
+| image-tag                      | New helm chart docker image tag, optional default chart-version | Optional            |
+| overwrite-parent-key-image-tag | Overwrite parent image key name, optional default empty         | Optional            |
+| no-tag                         | Do not upgrade an image tag in values                           | Optional            |
+| dependency-version             | New helm chart dependency version                               | Optional            |
+| dependency-name                | Helm chart dependency to upgrade                                | Optional            |
+| git-user                       | Git user name for commit, set only if autocommit is desired     | Optional            |
+| git-user-email                 | Git user email for commit, set only if autocommit is desired    | Optional            |
+| token                          | Github token for commit, set only if autocommit is desired      | Optional            |

--- a/install-node/action.yaml
+++ b/install-node/action.yaml
@@ -27,7 +27,7 @@ runs:
       shell: bash
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ inputs.version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.version }}
         cache: ${{ inputs.dependency-manager }}

--- a/install-node/action.yaml
+++ b/install-node/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
     - run: echo "Checkout Repository"
       shell: bash
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ inputs.version }}
       uses: actions/setup-node@v3
       with:

--- a/is-latest-tag/README.md
+++ b/is-latest-tag/README.md
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         # the full history is required for is-latest-tag
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             fetch-depth: 0
         - uses: greenbone/actions/is-latest-tag@v3

--- a/is-latest-tag/README.md
+++ b/is-latest-tag/README.md
@@ -36,6 +36,6 @@ jobs:
 
 ## Output Arguments
 
-|Output Variable|Description|
-|---------------|-----------|
-| is-latest-tag | Evaluates to true if the created tag is the latest git tag |
+| Output Variable | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| is-latest-tag   | Evaluates to true if the created tag is the latest git tag |

--- a/lint-golang/action.yml
+++ b/lint-golang/action.yml
@@ -19,7 +19,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.version }}

--- a/lint-golang/action.yml
+++ b/lint-golang/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.version }}
     - name: Generate code

--- a/pypi-upload/action.yaml
+++ b/pypi-upload/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
     - name: Set up Python

--- a/sbom-upload/action.yml
+++ b/sbom-upload/action.yml
@@ -19,7 +19,7 @@ branding:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         token: ${{ inputs.token }}
     - name: Generate SBOM

--- a/sign-release-files/action.yml
+++ b/sign-release-files/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
     - name: Checkout repository
       if: steps.checkout.outputs.exists != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python and pontos
       uses: greenbone/actions/setup-pontos@v3
       with:


### PR DESCRIPTION


## What

Update actions/checkout v3 to v4

## Why

Avoid the `Node.js 16 actions are deprecated` warning.

## References

https://github.com/greenbone/autohooks/actions/runs/7665538693


