### PR TITLE
Add: BSL-1.0

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -47,3 +47,4 @@ runs:
           OFL-1.1,
           Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1,
           BlueOak-1.0.0
+          BSL-1.0


### PR DESCRIPTION
Adds the attribution only license:
- https://opensource.org/license/bsl-1-0/

This required for openvasd tls functionality:

https://github.com/greenbone/openvas-scanner/blob/openvasd-hyper-hyper/rust/Cargo.lock#L2754
