### PR TITLE
Add: Markdown formatted message as input parameter for notify-action

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -115,7 +115,7 @@ runs:
     - name: Free input
       if: ${{ inputs.free }} 
       shell: bash
-      run: echo "ARGS=--free \"${{ inputs.free }}"" >> $GITHUB_ENV
+      run: echo "ARGS=--free \"${{ inputs.free }}\"" >> $GITHUB_ENV
       
     - name: Execute Mattermost-Notify
       shell: bash

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -80,9 +80,9 @@ runs:
           ARGS+=(--commit "${{ inputs.commit }}")
         fi
 
-        if [ -n "${{ inputs.commit-message }}" ]; then
+#        if [ -n "${{ inputs.commit-message }}" ]; then
           ARGS+=(--commit-message "${{ inputs.commit-message }}")
-        fi
+#        fi
 
         if [ -n "${{ inputs.branch }}" ]; then
           ARGS+=(--branch "${{ inputs.branch }}")

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -25,6 +25,8 @@ inputs:
     default: ${{ github.sha }}
   commit-message:
     description: Git commit message to use
+  free:
+    description: Free textmessage
   repository:
     description: GitHub repository (org/repo). Default is 'github.repository'
     default: ${{ github.repository }}
@@ -103,6 +105,10 @@ runs:
           for HIGHLIGHT in "${HIGHLIGHTS[@]}"; do
             ARGS+=("$HIGHLIGHT")
           done
+        fi
+
+        if [ -n "${{ inputs.free }}" ]; then
+          ARGS+=(--free "${{ inputs.free }}")
         fi
 
         mnotify-git "${ARGS[@]}"

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -80,9 +80,9 @@ runs:
           ARGS+=(--commit "${{ inputs.commit }}")
         fi
 
-#        if [ -n "${{ inputs.commit-message }}" ]; then
+        if [ -n "${{ inputs.commit-message }}" ]; then
           ARGS+=(--commit-message "${{ inputs.commit-message }}")
-#        fi
+        fi
 
         if [ -n "${{ inputs.branch }}" ]; then
           ARGS+=(--branch "${{ inputs.branch }}")

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -80,9 +80,9 @@ runs:
           ARGS+=(--commit "${{ inputs.commit }}")
         fi
 
-#        if [ -n "${{ inputs.commit-message }}" ]; then
-#          ARGS+=(--commit-message "${{ inputs.commit-message }}")
-#        fi
+        if [ -n "${{ inputs.commit-message }}" ]; then
+          ARGS+=(--commit-message "${{ inputs.commit-message }}")
+        fi
 
         if [ -n "${{ inputs.branch }}" ]; then
           ARGS+=(--branch "${{ inputs.branch }}")

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -112,6 +112,8 @@ runs:
           done
         fi
 
+        echo "ARGS=${ARGS[@]}" >> $GITHUB_ENV
+
     - name: Free input
       if: ${{ inputs.free }} 
       shell: bash

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -11,6 +11,9 @@ inputs:
   MATTERMOST_HIGHLIGHT:
     description: "highlight users in channel. Deprecated."
     deprecationMessage: "Deprecated. Use highlight instead."
+  commit-message:
+    description: Git commit message to use
+    deprecationMessage: "Deprecated. Connected commit message to commit will be used"  
   url:
     description: "Mattermost webhook url"
   channel:
@@ -23,9 +26,6 @@ inputs:
   commit:
     description: Git commit. Default is 'github.sha'.
     default: ${{ github.sha }}
-  commit-message:
-    description: Git commit message to use
-    deprecationMessage: "Deprecated. Connected commit message to commit will be used"
   message:
     description: Enter markeddown formated text
   repository:

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -25,6 +25,7 @@ inputs:
     default: ${{ github.sha }}
   commit-message:
     description: Git commit message to use
+    deprecationMessage: "Deprecated. Connected commit message to commit will be used"
   free:
     description: Free textmessage
   repository:
@@ -79,9 +80,9 @@ runs:
           ARGS+=(--commit "${{ inputs.commit }}")
         fi
 
-        if [ -n "${{ inputs.commit-message }}" ]; then
-          ARGS+=(--commit-message "${{ inputs.commit-message }}")
-        fi
+#        if [ -n "${{ inputs.commit-message }}" ]; then
+#          ARGS+=(--commit-message "${{ inputs.commit-message }}")
+#        fi
 
         if [ -n "${{ inputs.branch }}" ]; then
           ARGS+=(--branch "${{ inputs.branch }}")

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -79,8 +79,6 @@ runs:
         if [ -n "${{ inputs.commit }}" ]; then
           ARGS+=(--commit "${{ inputs.commit }}")
         fi
-
-        ARGS+=(--commit-message "${{ inputs.commit-message }}")
       
         if [ -n "${{ inputs.branch }}" ]; then
           ARGS+=(--branch "${{ inputs.branch }}")

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -80,10 +80,8 @@ runs:
           ARGS+=(--commit "${{ inputs.commit }}")
         fi
 
-        if [ -n "${{ inputs.commit-message }}" ]; then
-          ARGS+=(--commit-message "${{ inputs.commit-message }}")
-        fi
-
+        ARGS+=(--commit-message "${{ inputs.commit-message }}")
+      
         if [ -n "${{ inputs.branch }}" ]; then
           ARGS+=(--branch "${{ inputs.branch }}")
         fi

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -26,8 +26,8 @@ inputs:
   commit-message:
     description: Git commit message to use
     deprecationMessage: "Deprecated. Connected commit message to commit will be used"
-  free:
-    description: Free textmessage
+  message:
+    description: Enter markeddown formated text
   repository:
     description: GitHub repository (org/repo). Default is 'github.repository'
     default: ${{ github.repository }}

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -56,6 +56,7 @@ runs:
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit }}
+
     - name: Install
       if: ${{ !startsWith(runner.name, inputs.skip-installation-on) }}
       uses: greenbone/actions/pipx@v3
@@ -63,7 +64,13 @@ runs:
       with:
         python-version: "3.10"
         install: mattermost-notify
-    - name: Create the Mattermost Message
+
+    - name: Set Channel and Webhook
+      shell: bash
+      run: |
+        echo "POS_ARGS=${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }} ${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}" >> $GITHUB_ENV
+      
+    - name: Inputs for Github success notifications
       shell: bash
       run: |
         ARGS=()
@@ -96,8 +103,6 @@ runs:
           ARGS+=(--workflow_name "${{ inputs.workflow-name }}")
         fi
 
-        ARGS+=("${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }}" "${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}")
-
         if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" ] || [ -n "${{ inputs.highlight }}" ]; then
           ARGS+=(--highlight)
           # Add every highlight element as its own string
@@ -107,8 +112,11 @@ runs:
           done
         fi
 
-        if [ -n "${{ inputs.free }}" ]; then
-          ARGS+=(--free "${{ inputs.free }}")
-        fi
-
-        mnotify-git "${ARGS[@]}"
+    - name: Free input
+      if: ${{ inputs.free == 'true' }} 
+      shell: bash
+      run: echo "ARGS=--free \"${{ inputs.free }}"" >> $GITHUB_ENV
+      
+    - name: Execute Mattermost-Notify
+      shell: bash
+      run: mnotify-git ${{ env.POS_ARGS }} ${{ env.ARGS }}

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: Git commit. Default is 'github.sha'.
     default: ${{ github.sha }}
   message:
-    description: Enter markeddown formated text
+    description: Enter a markdown formatted text message. Note: Setting a string in this argument ignores all other arguments.
   repository:
     description: GitHub repository (org/repo). Default is 'github.repository'
     default: ${{ github.repository }}
@@ -111,7 +111,7 @@ runs:
 
         echo "ARGS=${ARGS[@]}" >> $GITHUB_ENV
 
-    - name: Free input
+    - name: Use markdown formatted message, if it is set.
       if: ${{ inputs.free }}
       shell: bash
       run: echo "ARGS=--free \"${{ inputs.free }}\"" >> $GITHUB_ENV

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
       run: |
         echo "POS_ARGS=${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }} ${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}" >> $GITHUB_ENV
-      
+
     - name: Inputs for Github success notifications
       shell: bash
       run: |
@@ -100,7 +100,7 @@ runs:
         fi
 
         if [ -n "${{ inputs.workflow-name }}" ]; then
-          ARGS+=(--workflow_name "${{ inputs.workflow-name }}")
+          ARGS+=(--workflow_name \""${{ inputs.workflow-name }}\"")
         fi
 
         if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" ] || [ -n "${{ inputs.highlight }}" ]; then
@@ -115,7 +115,7 @@ runs:
         echo "ARGS=${ARGS[@]}" >> $GITHUB_ENV
 
     - name: Free input
-      if: ${{ inputs.free }} 
+      if: ${{ inputs.free }}
       shell: bash
       run: echo "ARGS=--free \"${{ inputs.free }}\"" >> $GITHUB_ENV
       

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -113,10 +113,11 @@ runs:
         fi
 
     - name: Free input
-      if: ${{ inputs.free == 'true' }} 
+      if: ${{ inputs.free }} 
       shell: bash
       run: echo "ARGS=--free \"${{ inputs.free }}"" >> $GITHUB_ENV
       
     - name: Execute Mattermost-Notify
       shell: bash
       run: mnotify-git ${{ env.POS_ARGS }} ${{ env.ARGS }}
+


### PR DESCRIPTION
## What
Added "Markdown formatted message" as input parameter for notify-action
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The program can use both, a free text message or a success notification with the existing inputs.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-956
[Mattermost-notify](https://github.com/greenbone/mattermost-notify/blob/main/mattermost_notify/parser.py)
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


