### PR TITLE
Add: Allow to set a repository for signing release files

### DIFF
--- a/sign-release-files/README.md
+++ b/sign-release-files/README.md
@@ -26,14 +26,15 @@ jobs:
 
 ## Action Configuration
 
-|Input Variable|Description| |
-|--------------|-----------|-|
-| python-version  | Python version to use for running the action. | Optional (default is `3.10`) |
-| git-tag-prefix  | Set git tag prefix to the passed input. Default: 'v' | Optional (default is `v`) |
-| gpg-fingerprint | GPG fingerprint, represented as a string. | Required |
-| gpg-key         | GPG key, represented as a string. | Required |
-| gpg-passphrase  | GPG passphrase, represented as a string. | Required |
-| release-version | Set an explicit version, that should be released. | Optional |
-| release-series  | Allow to determine release versions for an older release series like `"22.4"`. | Optional |
-| versioning-scheme | What versioning scheme should be used for the release? Supported: `"semver"`, `"pep440"` | Optional (default is `"pep440"`) |
-| github-token | Token with write rights for releases to download and upload release asset files. | Optional (default is `${{ github.token }}`) |
+| Input Variable    | Description                                                                              |                                                  |
+| ----------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| python-version    | Python version to use for running the action.                                            | Optional (default is `3.10`)                     |
+| git-tag-prefix    | Set git tag prefix to the passed input. Default: 'v'                                     | Optional (default is `v`)                        |
+| gpg-fingerprint   | GPG fingerprint, represented as a string.                                                | Required                                         |
+| gpg-key           | GPG key, represented as a string.                                                        | Required                                         |
+| gpg-passphrase    | GPG passphrase, represented as a string.                                                 | Required                                         |
+| release-version   | Set an explicit version, that should be released.                                        | Optional                                         |
+| release-series    | Allow to determine release versions for an older release series like `"22.4"`.           | Optional                                         |
+| versioning-scheme | What versioning scheme should be used for the release? Supported: `"semver"`, `"pep440"` | Optional (default is `"pep440"`)                 |
+| github-token      | Token with write rights for releases to download and upload release asset files.         | Optional (default is `${{ github.token }}`)      |
+| repository        | GitHub repository (owner/name) to download the release files from.                       | Optional (default is `${{ github.repository }}`) |

--- a/sign-release-files/action.yml
+++ b/sign-release-files/action.yml
@@ -30,6 +30,9 @@ inputs:
     description: "Set an explicit release version, that should be used. Otherwise it will be determined from the tags."
   release-series:
     description: "Allow to determine release versions for an older release series like '22.4'."
+  repository:
+    description: "GitHub repository (owner/name) to download the release files from."
+    default: ${{ github.repository }}
 
 branding:
   icon: "package"
@@ -81,6 +84,8 @@ runs:
     - name: Checkout repository
       if: steps.checkout.outputs.exists != 'true'
       uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
     - name: Set up Python and pontos
       uses: greenbone/actions/setup-pontos@v3
       with:
@@ -96,7 +101,7 @@ runs:
     - name: Sign files for released version
       run: |
         echo "Signing release files"
-        pontos-release sign ${{ env.ARGS }} --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
+        pontos-release sign ${{ env.ARGS }} --repository ${{ inputs.repository }} --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       if: ${{ inputs.sign-release-files == 'true' }} && ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
       env:


### PR DESCRIPTION


## What

Allow to set a repository for signing release files to fix signing releases files outside of greenbone

## Why

Make the signing of release assets more flexible and don't pin it to the greenbone organization. Currently only repos within the greenbone organization can be used.

By default the github.repository (the repo of the running workflow) is used.

