### PR TITLE
Release update

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -18,20 +18,20 @@ Currently supported programming languages:
 Currently this action can create different types of releases.
 Supported with the `release-type` argument are `major`, `minor`, `patch` and different type of `pre-releases`. Additionally you can also use `calendar` versioning.
 
-| Type              | Old version      | New version      |
-|-------------------|------------------|------------------|
-| major             |      `1.x.x`     |      `2.x.x`     |
-| minor             |      `x.1.x`     |      `x.2.x`     |
-| patch             |      `x.x.1`     |      `x.x.2`     |
-| alpha             |      `x.x.1`     |   `x.x.2-a1`     |
-| alpha             |   `x.x.2-a1`     |   `x.x.2-a2`     |
-| alpha             |   `x.x.2-alpha1` |   `x.x.2-alpha2` |
-| beta              |      `x.x.1`     |   `x.x.2-a1`     |
-| beta              |   `x.x.2-a1`     |   `x.x.2-b1`     |
-| release-candidate |   `x.x.2-a3`     |  `x.x.2-rc1`     |
-| release-candidate |      `x.x.2`     |  `x.x.3-rc1`     |
-| calendar          |     `20.5.1`     |     `23.2.0`     |
-| calendar          |     `23.2.1`     |     `23.2.2`     |
+| Type              | Old version    | New version    |
+| ----------------- | -------------- | -------------- |
+| major             | `1.x.x`        | `2.x.x`        |
+| minor             | `x.1.x`        | `x.2.x`        |
+| patch             | `x.x.1`        | `x.x.2`        |
+| alpha             | `x.x.1`        | `x.x.2-a1`     |
+| alpha             | `x.x.2-a1`     | `x.x.2-a2`     |
+| alpha             | `x.x.2-alpha1` | `x.x.2-alpha2` |
+| beta              | `x.x.1`        | `x.x.2-a1`     |
+| beta              | `x.x.2-a1`     | `x.x.2-b1`     |
+| release-candidate | `x.x.2-a3`     | `x.x.2-rc1`    |
+| release-candidate | `x.x.2`        | `x.x.3-rc1`    |
+| calendar          | `20.5.1`       | `23.2.0`       |
+| calendar          | `23.2.1`       | `23.2.2`       |
 
 You can alternatively set an explicit `release-version`. It will overwrite the `release-type` argument.
 
@@ -39,27 +39,28 @@ You can alternatively set an explicit `release-version`. It will overwrite the `
 
 ## Input arguments
 
-| Argument             | Description                                                                                                                                                                               | Required?                     |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| conventional-commits | Deprecated                                                                                                                                                                                | Optional                      |
-| git-tag-prefix       | Set git tag prefix to the passed input. Default: 'v'                                                                                                                                      | Optional (default is `v`)     |
-| github-user          | Github user name on behalf of whom the actions will be executed.                                                                                                                          | Yes                           |
-| github-user-mail     | Mail address for the given github user.                                                                                                                                                   | Yes                           |
-| github-user-token    | Token with write rights required to create the release.                                                                                                                                   | Yes                           |
-| gpg-fingerprint      | GPG fingerprint, represented as a string. Required for signing assets of the release.                                                                                                     | Optional                      |
-| gpg-key              | GPG key, represented as a string. Required for signing assets of the release.                                                                                                             | Optional                      |
-| gpg-passphrase       | GPG passphrase, represented as a string. Required for signing assets of the release.                                                                                                      | Optional                      |
-| strategy             | Deprecated by `release-type`.                                                                                                                                                             | Optional                      |
-| python-version       | Python version used to create the release. (Only important for python projects)                                                                                                           | Optional (default `"3.10"` )  |
-| ref                  | This branch's/tag's HEAD will be candidate of the next release.                                                                                                                           | Optional (default: `main`)    |
-| release-type         | What type of release should be executed? Supported: `alpha`, `beta`, `calendar`, `major`, `minor`, `patch`, `release-candidate`                                                           | Optional (default: `patch`)   |
-| release-version      | Set an explicit version, that should be released.                                                                                                                                         | Optional                      |
-| release-series       | Allow to determine release versions for an older release series like '22.4'.                                                                                                              | Optional                      | None |
-| versioning-scheme    | What versioning scheme should be used for the release? Supported: `semver`, `pep440`                                                                                                      | Optional (default: `pep440` ) |
-| sign-release-files   | Create and upload release file signatures. Default is 'true'. Set to an other string then 'true' to disable the signatures.                                                               | Optional (default `"true"`)   |
-| update-project       | Update version in project files like `pyproject.toml`. Default is 'true'. Set to an other string then 'true' to disable updating project files.                                           | Optional (default `"true"`)   |
-| next-version         | Set an explicit version that should be used after the release. Leave empty for determining the next version automatically. Set to `'false'` for not updating the version after a release. |                               |
-| github-pre-release   | Set to `'true'`` to enforce uploading the release to GitHub as a pre-release                                                                                                              |                               |
+| Argument             | Description                                                                                                                                                                               | Required?                                        |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| conventional-commits | Deprecated                                                                                                                                                                                | Optional                                         |
+| git-tag-prefix       | Set git tag prefix to the passed input. Default: 'v'                                                                                                                                      | Optional (default is `v`)                        |
+| github-user          | Github user name on behalf of whom the actions will be executed.                                                                                                                          | Yes                                              |
+| github-user-mail     | Mail address for the given github user.                                                                                                                                                   | Yes                                              |
+| github-user-token    | Token with write rights required to create the release.                                                                                                                                   | Yes                                              |
+| gpg-fingerprint      | GPG fingerprint, represented as a string. Required for signing assets of the release.                                                                                                     | Optional                                         |
+| gpg-key              | GPG key, represented as a string. Required for signing assets of the release.                                                                                                             | Optional                                         |
+| gpg-passphrase       | GPG passphrase, represented as a string. Required for signing assets of the release.                                                                                                      | Optional                                         |
+| strategy             | Deprecated by `release-type`.                                                                                                                                                             | Optional                                         |
+| python-version       | Python version used to create the release. (Only important for python projects)                                                                                                           | Optional (default `"3.10"` )                     |
+| ref                  | This branch's/tag's HEAD will be candidate of the next release.                                                                                                                           | Optional (default: `main`)                       |
+| release-type         | What type of release should be executed? Supported: `alpha`, `beta`, `calendar`, `major`, `minor`, `patch`, `release-candidate`                                                           | Optional (default: `patch`)                      |
+| release-version      | Set an explicit version, that should be released.                                                                                                                                         | Optional                                         |
+| release-series       | Allow to determine release versions for an older release series like '22.4'.                                                                                                              | Optional                                         | None |
+| versioning-scheme    | What versioning scheme should be used for the release? Supported: `semver`, `pep440`                                                                                                      | Optional (default: `pep440` )                    |
+| sign-release-files   | Create and upload release file signatures. Default is 'true'. Set to an other string then 'true' to disable the signatures.                                                               | Optional (default `"true"`)                      |
+| update-project       | Update version in project files like `pyproject.toml`. Default is 'true'. Set to an other string then 'true' to disable updating project files.                                           | Optional (default `"true"`)                      |
+| next-version         | Set an explicit version that should be used after the release. Leave empty for determining the next version automatically. Set to `'false'` for not updating the version after a release. |                                                  |
+| github-pre-release   | Set to `'true'`` to enforce uploading the release to GitHub as a pre-release                                                                                                              |                                                  |
+| repository           | GitHub repository (owner/name) to create the release for.                                                                                                                                 | Optional (default is `${{ github.repository }}`) |
 
 ## Output Arguments
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -59,6 +59,9 @@ inputs:
       "the version after a release."
   github-pre-release:
     description: "Set to 'true' to enforce uploading the release to GitHub as a pre-release"
+  repository:
+    description: "GitHub repository (owner/name) to create the release for."
+    default: ${{ github.repository }}
 
 outputs:
   release-version:
@@ -99,6 +102,7 @@ runs:
         fetch-depth: 0 # for conventional commits and getting all git tags
         persist-credentials: false
         ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository }}
     - name: Set git name, mail and origin
       uses: greenbone/actions/set-github-user@v3
       with:
@@ -178,7 +182,7 @@ runs:
       id: release
       run: |
         source ${{ steps.virtualenv.outputs.activate }}
-        pontos-release create ${{ env.ARGS }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
+        pontos-release create ${{ env.ARGS }} --repository ${{ inputs.repository }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       env:
         GITHUB_USER: ${{ inputs.github-user }}
@@ -207,3 +211,4 @@ runs:
         versioning-scheme: ${{ inputs.versioning-scheme }}
         release-series: ${{ inputs.release-series }}
         release-version: ${{ steps.release.outputs.release-version }}
+        repository: ${{ inputs.repository }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -178,7 +178,7 @@ runs:
       id: release
       run: |
         source ${{ steps.virtualenv.outputs.activate }}
-        pontos-release release ${{ env.ARGS }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
+        pontos-release create ${{ env.ARGS }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       env:
         GITHUB_USER: ${{ inputs.github-user }}


### PR DESCRIPTION
## What
Allow to pass a specific repository to be released

## Why

Currently it's not possible to create a release for a repository outside of the greenbone GitHub organization. With this change the current repo will be released which is not required to be a repo of the greenbone GitHub organization anymore.

