### PR TITLE
Change: image-url default to github.repository in container-build-push-generic action

### DIFF
--- a/container-build-push-generic/README.md
+++ b/container-build-push-generic/README.md
@@ -47,7 +47,7 @@ jobs:
 | cosign-key-password          | Cosign key password. Will be skipped if empty. Default is empty                                                    | Optional |
 | cosign-tlog-upload           | Turn on or turn off the cosign tlog upload function. Possible options: true/false Default is true                  | Optional |
 | image-labels                 | Image labels.                                                                                                      | Required |
-| image-url                    | Image url/name without registry.                                                                                   | Required |
+| image-url                    | Image url/name without registry. Default is github.repository                                                      | Optional |
 | image-platforms              | Image platforms to build for. Default is "linux/amd64"                                                             | Optional |
 | image-tags                   | Image tags.                                                                                                        | Required |
 | registry                     | Registry url.                                                                                                      | Required |

--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -27,8 +27,8 @@ inputs:
     description: "Image labels."
     required: true
   image-url:
-    description: "Image url/name without registry."
-    required: true
+    description: "Image url/name without registry. Default is github.repository"
+    default: "${{ github.repository }}"
   image-tags:
     description: "Image tags."
     required: true


### PR DESCRIPTION
# What
Change: image-url default to github.repository
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It is mostly the default in every repository.
<!-- Describe why are these changes necessary? -->

## References
None



