### PR TITLE
Change: Enable annotations in container-build-push-generic

### DIFF
--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -98,6 +98,7 @@ runs:
       id: build-and-push
       uses: docker/build-push-action@v4
       with:
+        annotations: ${{ steps.meta.outputs.annotations }}
         context: ${{ inputs.build-context }}
         push: ${{ github.event_name != 'pull_request' }}
         platforms: ${{ inputs.image-platforms }}


### PR DESCRIPTION
## What
Change: Enable annotations in container-build-push-generic
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Annotations allow you to define custom metadata for OCI image components, such as manifests.
The metadata action is designed to automatically generate OCI-compliant annotations.
https://docs.docker.com/build/ci/github-actions/annotations/
<!-- Describe why are these changes necessary? -->

## References
None


