### PR TITLE
Fix: Default path of download-artifact Action

### DIFF
--- a/download-artifact/README.md
+++ b/download-artifact/README.md
@@ -55,7 +55,7 @@ jobs:
 | workflow-events | Consider only workflow runs triggered by the specified events. | Optional (default is `"schedule, workflow_dispatch"`) |
 | repository | Repository of the workflow to trigger | Optional (default is `${{ github.repository }}` (current repository)) |
 | branch | The git branch for the workflow. | Optional (default is `"main"`) |
-| path | Destination path for the to be downloaded artifact of parent directory if name is not set. | Optional (default is `.` (Current directory)) |
+| path | Destination path for the to be downloaded artifact of parent directory if name is not set. | Optional (default is `${{ github.workspace }}`) |
 | name | Name of the artifact to be downloaded. If not set all artifacts will be downloaded. | Optional |
 | allow-not-found | Set to `"true"` to not fail if workflow or artifact can not be found. | Optional |
 | user | User ID for ownership of the downloaded artifacts. | Optional |

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -26,9 +26,9 @@ inputs:
     description: "Set to 'true' to not fail if workflow or artifact could not be found."
     default: "false"
   path:
-    description: "Path where to store the downloaded artifacts."
+    description: "Path where to store the downloaded artifacts (default is `${{ github.workspace }}`)."
     required: false
-    default: "."
+    default: ${{ github.workspace }}
   user:
     description: "User ID for ownership of the downloaded artifacts."
     required: false

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: "Set to 'true' to not fail if workflow or artifact could not be found."
     default: "false"
   path:
-    description: "Path where to store the downloaded artifacts (default is `${{ github.workspace }}`)."
+    description: "Path where to store the downloaded artifacts."
     required: false
     default: ${{ github.workspace }}
   user:


### PR DESCRIPTION
## What
This PR fixes the default of `path` of the download-artifact Action.

## Why
Using `.` as the default path is expected to refer to the current working directory. Currently however, it seems to refer to `.`, relative to the directory of the Action itself, see https://github.com/greenbone/notus-generator/actions/runs/7887096945/job/21521596772:
```
Run greenbone/actions/download-artifact@v3
  with:
[...]
    path: .
Extracting artifact '[redacted]' to '/home/runner/work/_actions/greenbone/actions/v3/download-artifact'.
Downloading artifacts completed successfully ✅.
Run ls -la
total 8
drwxr-xr-x 2 runner docker 4096 Feb 13 13:16 .
drwxr-xr-x 3 runner docker 4096 Feb 13 13:16 ..
```
Note that I haven't actually tested this change.

## References
Stumbled upon this while working on https://github.com/greenbone/notus-generator/pull/970, but not required for it.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


