### PR TITLE
Fix: Caching for Poetry Action

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -33,19 +33,19 @@ runs:
   using: "composite"
   steps:
     - name: Set up poetry
-      uses: actions/setup-python@v5
-      id: python
-      with:
-        python-version: ${{ inputs.python-version }}
-        cache: ${{ inputs.cache == 'true' && 'poetry' || '' }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
-    - name: Set up poetry
       uses: greenbone/actions/pipx@v3
       with:
         python-path: ${{ steps.python.outputs.python-path }}
         cache: ${{ inputs.cache-poetry-installation }}
         install: poetry
         install-version: ${{ inputs.poetry-version }}
+    - name: Set up poetry
+      uses: actions/setup-python@v5
+      id: python
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: ${{ inputs.cache == 'true' && 'poetry' || '' }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
     - name: Parse inputs
       if: ${{ inputs.install-dependencies == 'true' }}
       run: |


### PR DESCRIPTION
## What
This PR fixes caching for the Poetry Action.

## Why
Poetry needs to be installed before invoking `actions/setup-python` (see https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages), otherwise we run into https://github.com/greenbone/notus-generator/actions/runs/7898963936/job/21557417882#step:4:1.
Tested via https://github.com/greenbone/notus-generator/actions/runs/7898981345/job/21557514915#step:4:1.

## References
Noticed during implementation and required by https://github.com/greenbone/notus-generator/pull/970.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


