### PR TITLE
Fix: mattermost-notify Action

### DIFF
--- a/mattermost-notify/README.md
+++ b/mattermost-notify/README.md
@@ -73,7 +73,7 @@ jobs:
 | highlight | List of space separated users to highlight in the channel | Optional. |
 | branch | Git branch to use in the message | Optional. Default is `${{ github.ref_name }}`. Will be derived from the event if empty. |
 | commit | Git commit to use in the message | Optional. Default is `${{ github.sha }}`. Will be derived from the event if empty. |
-| commit-message | Git commit message to use in the message | Optional. Will be derived from the event if commit is empty. Otherwise it will be derived from the git log. |
+| commit-message | Git commit message to use in the message | Deprecated. Connected commit message to commit will be used |
 | repository | GitHub repository (org/repo) | Optional. Default is `${{ github.repository }}`. |
 | status | Specifies the notification status. Options success or failure. Default is automatic detected by `GITHUB_EVENT_PATH` json. | Optional. |
 | skip-installation-on | Skip mn-notify installation on selected runner. Default is self-hosted-generic. | Optional. |

--- a/mattermost-notify/README.md
+++ b/mattermost-notify/README.md
@@ -73,6 +73,7 @@ jobs:
 | highlight | List of space separated users to highlight in the channel | Optional. |
 | branch | Git branch to use in the message | Optional. Default is `${{ github.ref_name }}`. Will be derived from the event if empty. |
 | commit | Git commit to use in the message | Optional. Default is `${{ github.sha }}`. Will be derived from the event if empty. |
+| message | Enter a markdown formatted text message. Note: Setting a string in this argument ignores all other arguments. | Optional. |
 | commit-message | Git commit message to use in the message | Deprecated. Connected commit message to commit will be used |
 | repository | GitHub repository (org/repo) | Optional. Default is `${{ github.repository }}`. |
 | status | Specifies the notification status. Options success or failure. Default is automatic detected by `GITHUB_EVENT_PATH` json. | Optional. |

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: Git commit. Default is 'github.sha'.
     default: ${{ github.sha }}
   message:
-    description: Enter a markdown formatted text message. Note: Setting a string in this argument ignores all other arguments.
+    description: "Enter a markdown formatted text message. Note: Setting a string in this argument ignores all other arguments."
   repository:
     description: GitHub repository (org/repo). Default is 'github.repository'
     default: ${{ github.repository }}

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -112,9 +112,9 @@ runs:
         echo "ARGS=${ARGS[@]}" >> $GITHUB_ENV
 
     - name: Use markdown formatted message, if it is set.
-      if: ${{ inputs.free }}
+      if: ${{ inputs.message }}
       shell: bash
-      run: echo "ARGS=--free \"${{ inputs.free }}\"" >> $GITHUB_ENV
+      run: echo "ARGS=--free \"${{ inputs.message }}\"" >> $GITHUB_ENV
       
     - name: Execute Mattermost-Notify
       shell: bash


### PR DESCRIPTION
## What
This PR fixes the mattermost-notify Action / https://github.com/greenbone/actions/pull/997.

## Why
- Using `:` in an unquoted string makes YAML sad
- `inputs.free` doesn't exist, so I assume `inputs.message` is actually meant

## References
Tested in https://github.com/greenbone/notus-generator/actions/runs/7901348733/job/21564795251 as part of https://github.com/greenbone/notus-generator/pull/970.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


