### PR TITLE
Fix: Escaping in mattermost-notify Action

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -114,7 +114,7 @@ runs:
     - name: Use markdown formatted message, if it is set.
       if: ${{ inputs.message }}
       shell: bash
-      run: echo "ARGS=--free \"${{ inputs.message }}\"" >> $GITHUB_ENV
+      run: printf "ARGS=--free %q" '${{ inputs.message }}' >> $GITHUB_ENV
     - name: Execute Mattermost-Notify
       shell: bash
       run: mnotify-git ${{ env.POS_ARGS }} ${{ env.ARGS }}


### PR DESCRIPTION
## What
This PR fixes escaping of strings in the mattermost-notify Action.

## Why
Currently it's really hard to use a message when it is the output of another application.
As a user I don't want to take care of the escaping needed (e.g. when the message contains special characters interpreted by Bash), but just want to get my message sent.

Tested in https://github.com/greenbone/notus-generator/actions/runs/7987120546/job/21808941466?pr=970#step:5:332.

## References
Noticed during https://github.com/greenbone/notus-generator/pull/970.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


