### PR TITLE
Add: multi line output support in oci-info

### DIFF
--- a/oci-info/action.yml
+++ b/oci-info/action.yml
@@ -158,4 +158,4 @@ runs:
 
         # We need a clear exit code
         output="$(poetry run oci-info "${cmd[@]}")"
-        echo "output=$output" >> "$GITHUB_OUTPUT"
+        echo "output<<EOF"$'\n'"$output"$'\n'EOF >> $GITHUB_OUTPUT

--- a/oci-info/action.yml
+++ b/oci-info/action.yml
@@ -157,5 +157,5 @@ runs:
         fi
 
         # We need a clear exit code
-        output=$(poetry run oci-info "${cmd[@]}")
+        output="$(poetry run oci-info "${cmd[@]}")"
         echo "output=$output" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What
Add: multi line output support

## Why
The get-tags command returns a new line list.
<!-- Describe why are these changes necessary? -->

## References
None



