### PR TITLE
Make is-latest-tag action more flexible

### DIFF
--- a/.github/workflows/test-is-latest-tag.yml
+++ b/.github/workflows/test-is-latest-tag.yml
@@ -1,0 +1,165 @@
+name: Test Is Latest Tag Action
+
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-older-tag:
+    runs-on: ubuntu-latest
+    name: Test older Tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Repo and Tag
+        run: |
+          mkdir -p /tmp/repo
+          cd /tmp/repo
+          git config --global init.defaultBranch main
+          git config --global user.email "you@example.com"
+          git config --global user.name "Some User"
+          git init
+          touch some.file
+          git add some.file
+          git commit -m "Initial commit"
+          git tag v1.2.3
+      - name: Test is-latest-tag
+        uses: ./is-latest-tag
+        id: is-latest-tag
+        with:
+          tag-name: v1.2.2
+          working-directory: /tmp/repo
+      - name: Assert
+        run: |
+            if [[ "${{ steps.is-latest-tag.outputs.is-latest-tag }}" = "true" ]]; then
+              echo "::error::The tag 1.2.2 is not the latest tag"
+              exit 1
+            fi
+
+  test-newer-tag:
+    runs-on: ubuntu-latest
+    name: Test newer Tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Repo and Tag
+        run: |
+          mkdir -p /tmp/repo
+          cd /tmp/repo
+          git config --global init.defaultBranch main
+          git config --global user.email "you@example.com"
+          git config --global user.name "Some User"
+          git init
+          touch some.file
+          git add some.file
+          git commit -m "Initial commit"
+          git tag v1.2.3
+      - name: Test is-latest-tag
+        uses: ./is-latest-tag
+        id: is-latest-tag
+        with:
+          tag-name: v1.2.4
+          working-directory: /tmp/repo
+      - name: Assert
+        run: |
+            if [[ "${{ steps.is-latest-tag.outputs.is-latest-tag }}" != "true" ]]; then
+              echo "::error::The tag 1.2.4 is the latest tag"
+              exit 1
+            fi
+
+  test-is-latest-tag:
+    runs-on: ubuntu-latest
+    name: Test is latest Tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Repo and Tag
+        run: |
+          mkdir -p /tmp/repo
+          cd /tmp/repo
+          git config --global init.defaultBranch main
+          git config --global user.email "you@example.com"
+          git config --global user.name "Some User"
+          git init
+          touch some.file
+          git add some.file
+          git commit -m "Initial commit"
+          git tag v1.2.3
+      - name: Test is-latest-tag
+        uses: ./is-latest-tag
+        id: is-latest-tag
+        with:
+          tag-name: v1.2.3
+          working-directory: /tmp/repo
+      - name: Assert
+        run: |
+            if [[ "${{ steps.is-latest-tag.outputs.is-latest-tag }}" != "true" ]]; then
+              echo "::error::The tag 1.2.3 is the latest tag"
+              exit 1
+            fi
+
+  test-branch-as-tag-name:
+    runs-on: ubuntu-latest
+    name: Test branch as latest Tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Repo and Tag
+        run: |
+          mkdir -p /tmp/repo
+          cd /tmp/repo
+          git config --global init.defaultBranch main
+          git config --global user.email "you@example.com"
+          git config --global user.name "Some User"
+          git init
+          touch some.file
+          git add some.file
+          git commit -m "Initial commit"
+          git tag v1.2.3
+      - name: Test is-latest-tag
+        uses: ./is-latest-tag
+        id: is-latest-tag
+        with:
+          tag-name: some-branch
+          working-directory: /tmp/repo
+      - name: Assert
+        run: |
+            if [[ "${{ steps.is-latest-tag.outputs.is-latest-tag }}" = "true" ]]; then
+              echo "::error::The branch some-branch is not the latest tag"
+              exit 1
+            fi
+
+  test-empty-tag-name:
+    runs-on: ubuntu-latest
+    name: Test empty tag name as latest Tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Repo and Tag
+        run: |
+          mkdir -p /tmp/repo
+          cd /tmp/repo
+          git config --global init.defaultBranch main
+          git config --global user.email "you@example.com"
+          git config --global user.name "Some User"
+          git init
+          touch some.file
+          git add some.file
+          git commit -m "Initial commit"
+          git tag v1.2.3
+      - name: Test is-latest-tag
+        uses: ./is-latest-tag
+        id: is-latest-tag
+        with:
+          tag-name: ""
+          working-directory: /tmp/repo
+      - name: Assert
+        run: |
+            if [[ "${{ steps.is-latest-tag.outputs.is-latest-tag }}" = "true" ]]; then
+              echo "::error::An empty tag name is not the latest tag"
+              exit 1
+            fi

--- a/is-latest-tag/README.md
+++ b/is-latest-tag/README.md
@@ -3,7 +3,8 @@
 GitHub Action to check if a git tag is the latest tag.
 
 Please keep in mind that the full history (`checkout with fetch-depth 0`) is
-required for the `is-latest-tag` action.
+required for the `is-latest-tag` action. A tag is considered latest if its
+version is greater or equal as the latest existing tag.
 
 ## Example
 
@@ -33,6 +34,13 @@ jobs:
           run: |
             # do something else if the current tag is not the latest tag
 ```
+
+## Input Arguments
+
+| Input Variable    | Description                                                                       | Default                   |
+| ----------------- | --------------------------------------------------------------------------------- | ------------------------- |
+| tag-name          | Name of the tag to check if it is the latest tag                                  | `${{ github.ref_name }}`  |
+| working-directory | Working directory for the action. Has to reference the directory of the checkout. | `${{ github.workspace }}` |
 
 ## Output Arguments
 

--- a/is-latest-tag/action.yml
+++ b/is-latest-tag/action.yml
@@ -2,6 +2,13 @@ name: "Check if a tag is the latest tag in a repository"
 author: "Björn Ricks <bjoern.ricks@greenbone.net>"
 description: "An action to check if a tag is the latest tag in a repository"
 
+inputs:
+  tag-name:
+    description: "Name of the tag to check. Defaults to `github.ref_name`."
+    default: ${{ github.ref_name }}
+  working-directory:
+    description: "Working directory for the action. Defaults to `github.workspace`."
+    default: ${{ github.workspace }}
 outputs:
   is-latest-tag:
     description: Evaluates to true if the created tag is the latest git tag
@@ -17,33 +24,36 @@ runs:
     - name: "set is-latest-tag"
       id: latest
       run: |
-        if [ "${{ github.ref_type }}" = "tag" ]; then
-          # find the latest version that is not ourself
-          export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort | head -n 1)
+        # no tag name given
+        if [[ -z "${{ inputs.tag-name }}" ]]; then
+          echo "is-latest-tag=false" >> $GITHUB_OUTPUT
+        fi
 
-          # get major minor patch versions
-          IFS='.' read -r latest_major latest_minor latest_patch << EOF
+        # find the latest version that is not ourself
+        TAGS=$(git tag -l)
+        export LATEST_VERSION=$(echo $TAGS | grep -v '${{ inputs.tag-name }}' | sort -r --version-sort | head -n 1)
+
+        # get major minor patch versions
+        IFS='.' read -r latest_major latest_minor latest_patch << EOF
         $LATEST_VERSION
         EOF
 
-          IFS='.' read -r tag_major tag_minor tag_patch << EOF
-        ${{ github.ref_name }}
+        IFS='.' read -r tag_major tag_minor tag_patch << EOF
+        ${{ inputs.tag-name }}
         EOF
 
-          # remove leading v
-          latest_major=$(echo $latest_major | cut -c2-)
-          tag_major=$(echo $tag_major | cut -c2-)
+        # remove leading v
+        latest_major=$(echo $latest_major | cut -c2-)
+        tag_major=$(echo $tag_major | cut -c2-)
 
-          if [[ $tag_major -gt $latest_major ]]; then
-            echo "is-latest-tag=true" >> $GITHUB_OUTPUT
-          elif [[ $tag_major -eq $latest_major && $tag_minor -gt $latest_minor ]]; then
-            echo "is-latest-tag=true" >> $GITHUB_OUTPUT
-          elif [[ $tag_major -eq $latest_major && $tag_minor -eq $latest_minor && $tag_patch -gt $latest_patch ]]; then
-            echo "is-latest-tag=true" >> $GITHUB_OUTPUT
-          else
-            echo "is-latest-tag=false" >> $GITHUB_OUTPUT
-          fi
+        if [[ $tag_major -gt $latest_major ]]; then
+          echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+        elif [[ $tag_major -eq $latest_major && $tag_minor -gt $latest_minor ]]; then
+          echo "is-latest-tag=true" >> $GITHUB_OUTPUT
+        elif [[ $tag_major -eq $latest_major && $tag_minor -eq $latest_minor && $tag_patch -gt $latest_patch ]]; then
+          echo "is-latest-tag=true" >> $GITHUB_OUTPUT
         else
-            echo "is-latest-tag=false" >> $GITHUB_OUTPUT
+          echo "is-latest-tag=false" >> $GITHUB_OUTPUT
         fi
+      working-directory: ${{ inputs.working-directory }}
       shell: bash


### PR DESCRIPTION


## What

Make is-latest-tag action more flexible
## Why

Allow to run the action not only for pushed tag events. With this change it will be possible to run it even for workflow_dispatch events.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


