### PR TITLE
Add: Support label for calendar release type

### DIFF
--- a/release-type/action.yml
+++ b/release-type/action.yml
@@ -46,6 +46,10 @@ runs:
       run: |
         echo "RELEASE_TYPE=beta" >> $GITHUB_ENV
       shell: bash
+    - if: contains(github.event.pull_request.labels.*.name, 'make release')
+      run: |
+        echo "RELEASE_TYPE=calendar" >> $GITHUB_ENV
+      shell: bash
     - name: Workflow_dispatch RELEASE_TYPE
       if: github.event_name == 'workflow_dispatch'
       run: |


### PR DESCRIPTION
## What

Support label for calendar release type

## Why

Extend release-type action to support setting the `make release` label for creating a new calver based release.


