### PR TITLE
Add: Support setting "calendar release" label for release type calendar

### DIFF
--- a/release-type/action.yml
+++ b/release-type/action.yml
@@ -46,7 +46,7 @@ runs:
       run: |
         echo "RELEASE_TYPE=beta" >> $GITHUB_ENV
       shell: bash
-    - if: contains(github.event.pull_request.labels.*.name, 'make release')
+    - if: contains(github.event.pull_request.labels.*.name, 'make release') || contains(github.event.pull_request.labels.*.name, 'calendar release')
       run: |
         echo "RELEASE_TYPE=calendar" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION


## What

Support setting "calendar release" label for release type calendar

## Why

Cloud uses this label for creating calendar releases. Therefore the release-type action should support it too.