### PR TITLE
Add: Allow CAL-1.0 license

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -50,4 +50,5 @@ runs:
           BlueOak-1.0.0,
           BSL-1.0,
           Python-2.0.1,
-          MIT AND PSF-2.0
+          MIT AND PSF-2.0,
+          CAL-1.0


### PR DESCRIPTION
## What

Allow CAL-1.0 License when checking dependencies.

## Why

The CAL-1.0 license is triggered by [Pillow](https://github.com/python-pillow/Pillow) which is a dependency of [pheme](https://github.com/greenbone/pheme). Please see [LEG-146](https://jira.greenbone.net/browse/LEG-146)

## References
LEG-146


