### PR TITLE
Fix: oci info auth

### DIFF
--- a/oci-info/action/oci.py
+++ b/oci-info/action/oci.py
@@ -77,7 +77,7 @@ class Oci(httpx.Client):
             headers={"accept": ",".join([h.value for h in OciMediaTypes])},
         )
 
-        self.user_auth = (user, password) if user else None
+        self.user_auth = (user, password) if user and password else None
         self.reg_domain = reg_domain
         self.reg_auth_domain = reg_auth_domain
         self.reg_auth_service = reg_auth_service


### PR DESCRIPTION
## What
Fix: oci info auth
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
OCI authentication is only allowed to exist within the HTTP context of the token request. Therefore, now the authentication context is explicitly set for the token request.
<!-- Describe why are these changes necessary? -->

## References
None



