### PR TITLE
Fix: pr-conventional-commit-labeler: crash on empty labels set

### DIFF
--- a/pr-conventional-commit-labeler/action/labels.py
+++ b/pr-conventional-commit-labeler/action/labels.py
@@ -139,9 +139,10 @@ class Labels:
             await api.labels.delete_all(
                self.repository, self.pull_request
             )
-            await api.labels.set_all(
-                self.repository, self.pull_request, list(labels)
-            )
+            if labels:
+                await api.labels.set_all(
+                    self.repository, self.pull_request, list(labels)
+                )
 
 
 def main() -> NoReturn:


### PR DESCRIPTION
To prevent a crash when trying to set empty labels on a PR `labels`
should be checked before transmitting to github.
