### PR TITLE
Change: Do not use deprecated ruff CLI

### DIFF
--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -50,6 +50,12 @@ runs:
       name: Check with black
       working-directory: ${{ inputs.working-directory }}
     - run: poetry run ${{ inputs.linter }} ${{ inputs.packages }}
+      if: ${{ inputs.linter != 'ruff' }}
       shell: bash
       name: Check with ${{ inputs.linter }}
+      working-directory: ${{ inputs.working-directory }}
+    - run: poetry run ruff check ${{ inputs.packages }}
+      if: ${{ inputs.linter == 'ruff' }}
+      shell: bash
+      name: Check with ruff
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## What
Using ruff 0.4.3, we get the following warning 

> warning: ruff <path> is deprecated. Use ruff check <path> instead.

when using the `lint-python` action with `linter` set to `ruff`.

I have not tested this locally. If that is expected, could you point my to some piece of information on how to do it?

## Why

The behavior of `ruff .` may change in future versions.

