### PR TITLE
Allow `Apache-2.0 AND MIT AND NOASSERTION` as license combination

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -47,6 +47,7 @@ runs:
           (MIT OR Apache-2.0) AND Unicode-DFS-2016,
           OFL-1.1,
           Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1,
+          Apache-2.0 AND MIT AND NOASSERTION,
           BlueOak-1.0.0,
           BSL-1.0,
           Python-2.0.1,


### PR DESCRIPTION


## What

Allow `Apache-2.0 AND MIT AND NOASSERTION` as license combination

## Why
This license combination is detected for lxml-stub a Python package that contains typings for lxml.

## References
https://github.com/greenbone/python-gvm/pull/1127#issuecomment-2014454683
