### PR TITLE
Revert "Allow `Apache-2.0 AND MIT AND NOASSERTION` as license combination

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -47,7 +47,6 @@ runs:
           (MIT OR Apache-2.0) AND Unicode-DFS-2016,
           OFL-1.1,
           Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1,
-          Apache-2.0 AND MIT AND NOASSERTION,
           BlueOak-1.0.0,
           BSL-1.0,
           Python-2.0.1,


### PR DESCRIPTION
## What

This reverts commit 8a03b95ddc59ca2520bc2dd154f32d9f412cd8c9.

## Why


Despite being displayed as the license to add `Apache-2.0 AND MIT AND NOASSERTION` seems to be not a valid license combination and now causes errors on every dependency check.