### PR TITLE
Add: Allow LGPL-2.0-only AND LGPL-2.1-or-later as license combination

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -51,4 +51,5 @@ runs:
           BSL-1.0,
           Python-2.0.1,
           MIT AND PSF-2.0,
+          LGPL-2.0-only AND LGPL-2.1-or-later,
           CAL-1.0


### PR DESCRIPTION
## What
Add: Allow LGPL-2.0-only AND LGPL-2.1-or-later as license combination
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
```
The following dependencies have incompatible licenses:
  poetry.lock » astroid@3.2.2 – License: LGPL-2.0-only AND LGPL-2.1-or-later
  Error: Dependency review detected incompatible licenses. 

```
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


