### PR TITLE
Change: Disable docker load function in multi arch builds

### DIFF
--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -117,7 +117,7 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
-        load: ${{ github.event_name == 'pull_request' }}
+        load: ${{ github.event_name == 'pull_request' && !contains(inputs.image-platforms, ',') }}
 
     - name: Container signing
       if: ${{ github.event_name != 'pull_request' && inputs.cosign-key && inputs.cosign-key-password }}


### PR DESCRIPTION
## What
Change: Disable docker load function in multi arch builds
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The docker --load function does not support multi platform builds. So we need to disable them on this build mode.
https://github.com/docker/buildx/issues/59
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1069
<!-- Add identifier for issue tickets, links to other PRs, etc. -->




