### PR TITLE
Change: Make qemu local static binaries and buildx-container optional.

### DIFF
--- a/container-build-push-generic/README.md
+++ b/container-build-push-generic/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Container build and push docker.io
         uses: greenbone/actions/container-build-push-generic@v3
         with:
-          image-url: docker.io/my-image
+          image-url: my-image
           image-labels: my-labels
           image-tags: |
             type=ref,event=branch
@@ -39,27 +39,29 @@ jobs:
 
 | Name                         | Description                                                                                                                                 |          |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| build-context                | Path to image build context. Default is "."                                                                                                 | Optional |
-| build-docker-file            | Path to the docker file. Default is "./Dockerfile"                                                                                          | Optional |
-| build-args                   | Use these build-args for the docker build process. Default is empty                                                                         | Optional |
-| build-secrets                | Use these build-secrets for the docker build process. Default is empty                                                                      | Optional |
-| cosign-key                   | Cosign key to sign the image. Will be skipped if empty. Default is empty                                                                    | Optional |
-| cosign-key-password          | Cosign key password. Will be skipped if empty. Default is empty                                                                             | Optional |
-| cosign-tlog-upload           | Turn on or turn off the cosign tlog upload function. Possible options: true/false Default is true                                           | Optional |
+| build-context                | Path to image build context. Default is ".".                                                                                                | Optional |
+| build-docker-file            | Path to the docker file. Default is "./Dockerfile".                                                                                         | Optional |
+| build-args                   | Use these build-args for the docker build process. Default is empty.                                                                        | Optional |
+| build-secrets                | Use these build-secrets for the docker build process. Default is empty.                                                                     | Optional |
+| cosign-key                   | Cosign key to sign the image. Will be skipped if empty. Default is empty.                                                                   | Optional |
+| cosign-key-password          | Cosign key password. Will be skipped if empty. Default is empty.                                                                            | Optional |
+| cosign-tlog-upload           | Turn on or turn off the cosign tlog upload function. Options are true/false. Default is true.                                               | Optional |
 | image-labels                 | Image labels.                                                                                                                               | Required |
-| image-url                    | Image url/name without registry. Default is github.repository                                                                               | Optional |
-| image-platforms              | Image platforms to build for. Default is "linux/amd64"                                                                                      | Optional |
+| image-url                    | Image url/name without registry. Default is github.repository.                                                                              | Optional |
+| image-platforms              | Image platforms to build for. Default is "linux/amd64".                                                                                     | Optional |
 | image-tags                   | Image tags.                                                                                                                                 | Required |
-| meta-annotations-levels      | Comma separated list. Options are manifest, index, manifest-descriptor, index-descriptor. Default is manifest,manifest-descriptor .         | Optional |
+| meta-annotations-levels      | Comma separated list. Options are manifest, index, manifest-descriptor, index-descriptor. Default is manifest,manifest-descriptor.          | Optional |
 | registry                     | Registry url.                                                                                                                               | Required |
 | registry-username            | Login registry username.                                                                                                                    | Required |
 | registry-password            | Login registry password.                                                                                                                    | Required |
-| scout-command                | Comma separated list of several commands. Options are quickview, compare, cves, recommendations, sbom, environment. Default is cves,sbom .  | Optional |
-| scout-user                   | Dockerhub user for docker scout. Will be skipped if empty. Default is empty                                                                 | Optional |
-| scout-password               | Dockerhub user password for docker scout. Will be skipped if empty. Default is empty                                                        | Optional |
-| scout-keep-previous-comments | Keep but hide previous comment. If not set, keep and update one single comment per job. Default is `false`                                  | Optional |
-| sarif-retention-days         | Days to store the sarif artifact. Default is 1                                                                                              | Optional |
+| scout-command                | Comma separated list of several commands. Options are quickview, compare, cves, recommendations, sbom, environment. Default is cves,sbom.   | Optional |
+| scout-user                   | Dockerhub user for docker scout. Will be skipped if empty. Default is empty.                                                                | Optional |
+| scout-password               | Dockerhub user password for docker scout. Will be skipped if empty. Default is empty.                                                       | Optional |
+| scout-keep-previous-comments | Keep but hide previous comment. If not set, keep and update one single comment per job. Options are true/false. Default is false.           | Optional |
+| sarif-retention-days         | Days to store the sarif artifact. Default is 1.                                                                                             | Optional |
+| qemu                         | Install local QEMU static binaries. Options are true/false. Default is false.                                                               | Optional |
 | qemu-platforms               | Comma separated list of platforms to install. Options are amd64, arm64, arm, riscv64, s390x, 386. Default is arm64 (amd64 is default arch). | Optional |
+| buildx-container             | Use a buildx container to build images. Options are true/false. Default is true.                                                            | Optional |
 
 ## Action Output
 

--- a/container-build-push-generic/README.md
+++ b/container-build-push-generic/README.md
@@ -61,7 +61,7 @@ jobs:
 | sarif-retention-days         | Days to store the sarif artifact. Default is 1.                                                                                             | Optional |
 | qemu                         | Install local QEMU static binaries. Options are true/false. Default is false.                                                               | Optional |
 | qemu-platforms               | Comma separated list of platforms to install. Options are amd64, arm64, arm, riscv64, s390x, 386. Default is arm64 (amd64 is default arch). | Optional |
-| buildx-container             | Use a buildx container to build images. Options are true/false. Default is true.                                                            | Optional |
+| buildx-container             | Use a buildx container to build images. Options are true/false. Default is false.                                                           | Optional |
 
 ## Action Output
 

--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -3,36 +3,36 @@ description: Generic container build and push action.
 
 inputs:
   build-context:
-    description: "Path to image build context. Default is ."
+    description: "Path to image build context. Default is."
     default: .
   build-docker-file:
-    description: "Path to the docker file. Default is./Dockerfile"
+    description: "Path to the docker file. Default is./Dockerfile."
     default: "./Dockerfile"
   build-args:
-    description: "Use these build-args for the docker build process. Default is empty"
+    description: "Use these build-args for the docker build process. Default is empty."
   build-secrets:
-    description: "Use these build-secrets for the docker build process. Default is empty"
+    description: "Use these build-secrets for the docker build process. Default is empty."
   cosign-key:
-    description: "Cosign key to sign the image. Will be skipped if empty. Default is empty"
+    description: "Cosign key to sign the image. Will be skipped if empty. Default is empty."
   cosign-key-password:
-    description: "Cosign key password. Will be skipped if empty. Default is empty"
+    description: "Cosign key password. Will be skipped if empty. Default is empty."
   cosign-tlog-upload:
-    description: "Turn on or turn off the cosign tlog upload function. Possible options: true/false Default is true"
+    description: "Turn on or turn off the cosign tlog upload function. Options are true/false. Default is true."
     default: "true"
   image-labels:
     description: "Image labels."
     required: true
   image-url:
-    description: "Image url/name without registry. Default is github.repository"
+    description: "Image url/name without registry. Default is github.repository."
     default: "${{ github.repository }}"
   image-tags:
     description: "Image tags."
     required: true
   image-platforms:
-    description: "Image platforms to build for. Default is linux/amd64"
+    description: "Image platforms to build for. Default is linux/amd64."
     default: "linux/amd64"
   meta-annotations-levels:
-    description: "Comma separated list. Options are manifest, index, manifest-descriptor, index-descriptor. Default is manifest,manifest-descriptor ."
+    description: "Comma separated list. Options are manifest, index, manifest-descriptor, index-descriptor. Default is manifest,manifest-descriptor."
     default: "manifest,manifest-descriptor"
   registry:
     description: "Registry url."
@@ -44,21 +44,27 @@ inputs:
     description: "Login registry password."
     required: true
   scout-command:
-    description: "Comma separated list to run several commands. Options are quickview, compare, cves, recommendations, sbom, environment. Default is cves,sbom"
+    description: "Comma separated list to run several commands. Options are quickview, compare, cves, recommendations, sbom, environment. Default is cves,sbom."
     default: "cves,sbom"
   scout-user:
-    description: "Dockerhub user for docker scout. Will be skipped if empty. Default is empty"
+    description: "Dockerhub user for docker scout. Will be skipped if empty. Default is empty."
   scout-password:
-    description: "Dockerhub user password for docker scout. Will be skipped if empty. Default is empty"
+    description: "Dockerhub user password for docker scout. Will be skipped if empty. Default is empty."
   scout-keep-previous-comments:
-    description: "Keep but hide previous comment. If not set, keep and update one single comment per job. Default is `false`"
+    description: "Keep but hide previous comment. If not set, keep and update one single comment per job. Options are true/false. Default is false."
     default: false
   sarif-retention-days:
-    description: "Days to store the sarif artifact. Default is 1"
+    description: "Days to store the sarif artifact. Default is 1."
     default: 1
+  qemu:
+    description: "Install local QEMU static binaries. Options are true/false. Default is false."
+    default: "false"
   qemu-platforms:
     description: "Comma separated list of platforms to install. Options are amd64, arm64, arm, riscv64, s390x, 386. Default is arm64 (amd64 is default arch)."
     default: "arm64"
+  buildx-container:
+    description: "Use a buildx container to build images. Options are true/false. Default is true."
+    default: "true"
 
 outputs:
   digest:
@@ -80,11 +86,13 @@ runs:
         echo "name=$name" >> "$GITHUB_OUTPUT"
 
     - name: Set up QEMU
+      if: ${{ inputs.qemu == 'true' }}
       uses: docker/setup-qemu-action@v3
       with:
         platforms: ${{ inputs.qemu-platforms }}
 
     - name: Set up docker buildx
+      if: ${{ inputs.buildx-container == 'true' }}
       uses: docker/setup-buildx-action@v3
 
     - name: Login to docker registry

--- a/container-build-push-generic/action.yaml
+++ b/container-build-push-generic/action.yaml
@@ -63,8 +63,8 @@ inputs:
     description: "Comma separated list of platforms to install. Options are amd64, arm64, arm, riscv64, s390x, 386. Default is arm64 (amd64 is default arch)."
     default: "arm64"
   buildx-container:
-    description: "Use a buildx container to build images. Options are true/false. Default is true."
-    default: "true"
+    description: "Use a buildx container to build images. Options are true/false. Default is false."
+    default: "false"
 
 outputs:
   digest:


### PR DESCRIPTION
## What
Change: Make qemu local static binaries and buildx-container optional.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The docker daemon has now build in multi platform build support as long as the qemu files are installed.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1079
<!-- Add identifier for issue tickets, links to other PRs, etc. -->



