### PR TITLE
Add: Codecov token and flag for doc-coverage-clang

### DIFF
--- a/doc-coverage-clang/action.yml
+++ b/doc-coverage-clang/action.yml
@@ -1,6 +1,11 @@
 name: "Build XML documentation and upload coverage"
 author: "Jaspar Stach <jaspar.stach@greenbone.net>"
 description: "An action to upload documentation coverage to codecov.io for C Lang repository. Requires to run with the greenbone/doxygen docker image."
+
+inputs:
+  token:
+    description: "Upload token for codecov.io."
+
 branding:
   icon: "package"
   color: "green"
@@ -33,3 +38,5 @@ runs:
       uses: codecov/codecov-action@v4
       with:
         files: lcov.info
+        token: ${{ inputs.token }}
+        flags: documentation


### PR DESCRIPTION
## What
This adds the Codecov token to the doc-coverage-clang action, which is now required when not using fork repos for pull requests. Also, the flag "documentation" is added so the documentation coverage can be separated from other types like unit test coverage later.

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->



