### PR TITLE
Add: custom check rule for ruff

### DIFF
--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -12,14 +12,14 @@ inputs:
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
   cache:
-    description: "Cache dependencies by setting it to 'true'. Leave unset or set to an other string then 'true' to disable the cache."
+    description: "Cache dependencies by setting it to 'true'. Leave unset or set to another string then 'true' to disable the cache."
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
   cache-poetry-installation:
-    description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
+    description: "Cache poetry and its dependencies. Default is 'true'. Set to another string then 'true' to disable the cache."
     default: "true"
   install-dependencies:
-    description: "Install project dependencies. Default is 'true'. Set to an other string then 'true' to not install the dependencies."
+    description: "Install project dependencies. Default is 'true'. Set to another string then 'true' to not install the dependencies."
     default: "true"
   working-directory:
     description: "Working directory where to run the action"
@@ -49,7 +49,12 @@ runs:
       shell: bash
       name: Check with black
       working-directory: ${{ inputs.working-directory }}
-    - run: poetry run ${{ inputs.linter }} ${{ inputs.packages }}
+    - run: |
+        if [ "${{ inputs.linter }}" = "ruff" ]; then
+          poetry run ruff check ${{ inputs.packages }}
+        else
+          poetry run ${{ inputs.linter }} ${{ inputs.packages }}
+        fi
       shell: bash
       name: Check with ${{ inputs.linter }}
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## What

Adds a custom branch for ruff linting addressing the depreciated command "ruff ." -> "ruff check ."

## Why

Currently, the linting checks for python with ruff linter fails due to usage of "ruff ." instead of latest command "ruff check ."

