### PR TITLE
fix dependency review readme: add permissions to write to PR

### DIFF
--- a/dependency-review/README.md
+++ b/dependency-review/README.md
@@ -16,6 +16,7 @@ on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:


### PR DESCRIPTION
## What

Add permissions to write to PR to the dependency review example.

## Why

Using dependency review action without permission `pull-requests: write` issues a warning: `Warning: Unable to write summary to pull-request. Make sure you are giving this workflow the permission 'pull-requests: write'. `

## References

[Pipeline run with warning](https://github.com/greenbone/opensight-notification-service/actions/runs/9933940161/job/27437506097?pr=25#step:2:157)



