### PR TITLE
Change: newline separator for tags pass to cosign action

### DIFF
--- a/container-multi-arch-manifest/action.yaml
+++ b/container-multi-arch-manifest/action.yaml
@@ -89,7 +89,8 @@ runs:
         echo -e "tags=${meta_tags[@]}"
         # Set digest and tags output
         echo "digest=$manifest_digest" >> "$GITHUB_OUTPUT"
-        echo "tags=${meta_tags[@]}" >> "$GITHUB_OUTPUT"
+        # We need a newline separator here for the cosign action
+        echo "tags=$(printf "%s\n" "${meta_tags[@]}")" >> "$GITHUB_OUTPUT"
 
     - name: Signing Manifest
       if: ${{ inputs.cosign-key && inputs.cosign-key-password }}


### PR DESCRIPTION
## What
Change: newline separator for tags pass to cosign action
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
 We need a newline separator here for the cosign action
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1135



