### PR TITLE
Add: Allow 'LGPL-3.0-or-later' license

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -42,6 +42,7 @@ runs:
           LGPL-2.1,
           LGPL-3.0-only,
           LGPL-3.0,
+          LGPL-3.0-or-later,
           MIT,
           MPL-1.1,
           MPL-2.0,
@@ -51,7 +52,7 @@ runs:
           Python-2.0.1,
           Unicode-DFS-2016,
           Unlicense
-# Only single licenses are allowed in this list. 
-# A combination of licenses like `License-A AND License-B` 
+# Only single licenses are allowed in this list.
+# A combination of licenses like `License-A AND License-B`
 # is not supported. See:
 # https://github.com/actions/dependency-review-action/issues/792


### PR DESCRIPTION
## What
- Allow the 'LGPL-3.0-or-later' license in the dependency review action
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
We had a dependency that uses the 'LGPL-3.0-or-later' license. It was verified to be allowed, and is therefore added in this PR.
Please check the list of allowed licenses.
<!-- Describe why are these changes necessary? -->

## References
T5-1074
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [N/A] Tests


