### PR TITLE
Fix: pipx action don't set --python arg if no other python version is installed

### DIFF
--- a/pipx/action.yml
+++ b/pipx/action.yml
@@ -101,7 +101,7 @@ runs:
 
         if [ -n "${{ inputs.python-path }}" ]; then
           ARGS+=( "--python" "${{ inputs.python-path }}" )
-        else
+        elif [ -n "${{ steps.python.outputs.python-path }}" ]; then
           ARGS+=( "--python" "${{ steps.python.outputs.python-path }}" )
         fi
 


### PR DESCRIPTION
## What
Fix: pipx action don't set --python arg if no other python version is installed
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
DEVOPS-1272
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1272

## Tests
In pipeline tested

