### PR TITLE
Pin mattermost-notify

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -68,6 +68,7 @@ runs:
       with:
         python-version: "3.10"
         install: mattermost-notify
+        install-version: "24.11.2"
 
     - name: Set Channel and Webhook
       shell: bash


### PR DESCRIPTION
## What

This PR pins the pip package version )that is being installed during each run) to the current stable version.

## Why

Currently the action is always using the last published package on PyPi. Pinning the is needed so changes to the code can be made, without switching everyone over to the new version immidiatly.

## References

Ticket: [DEVOPS-1269](https://jira.greenbone.net/browse/DEVOPS-1269)

