### PR TITLE
Allow use of short format status updates

### DIFF
--- a/mattermost-notify/README.md
+++ b/mattermost-notify/README.md
@@ -74,6 +74,7 @@ jobs:
 | branch | Git branch to use in the message | Optional. Default is `${{ github.ref_name }}`. Will be derived from the event if empty. |
 | commit | Git commit to use in the message | Optional. Default is `${{ github.sha }}`. Will be derived from the event if empty. |
 | message | Enter a markdown formatted text message. Note: Setting a string in this argument ignores all other arguments. | Optional. |
+| shortline | If set to "true", the message will be sent as a short line | Optional. |
 | commit-message | Git commit message to use in the message | Deprecated. Connected commit message to commit will be used |
 | repository | GitHub repository (org/repo) | Optional. Default is `${{ github.repository }}`. |
 | status | Specifies the notification status. Options success or failure. Default is automatic detected by `GITHUB_EVENT_PATH` json. | Optional. |

--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -42,6 +42,9 @@ inputs:
   workflow-name:
     description: GitHub workflow name. Default is 'github.workflow'
     default: ${{ github.workflow }}
+  shortline:
+    description: "Set to 'true' to output git changes in a single line for a more concise format."
+    default: "false"
 
 branding:
   icon: "package"
@@ -98,6 +101,10 @@ runs:
 
         if [ -n "${{ inputs.workflow-name }}" ]; then
           ARGS+=(--workflow_name \""${{ inputs.workflow-name }}\"")
+        fi
+
+        if [[ ! "${{ inputs.shortline }}" == "false" ]]; then
+          ARGS+=(--short)
         fi
 
         if [ -n "${{ inputs.MATTERMOST_HIGHLIGHT }}" ] || [ -n "${{ inputs.highlight }}" ]; then


### PR DESCRIPTION
## What

This PR allows use of the `--short` flag to trigger short format messages for git status updates.

## Why

The flag could not be controlled via the action yet.

## References

Ref.: [DEVOPS-1269](https://jira.greenbone.net/browse/DEVOPS-1269)

