### PR TITLE
Change: use pypa/gh-action-pypi-publish v1.11.0

### DIFF
--- a/pypi-upload/action.yaml
+++ b/pypi-upload/action.yaml
@@ -37,6 +37,6 @@ runs:
         poetry build
       shell: bash
     - name: Upload
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@fb13cb306901256ace3dab689990e13a5550ffaa # v1.11.0
       with:
         password: ${{ inputs.pypi-token }}


### PR DESCRIPTION
## What
Change: use pypa/gh-action-pypi-publish v1.11.0
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It looks like the current v1 does not work in our setup anymore
<!-- Describe why are these changes necessary? -->

## References
None



