### PR TITLE
Add: Unicode-3.0

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -51,6 +51,7 @@ runs:
           Python-2.0,
           Python-2.0.1,
           Unicode-DFS-2016,
+          Unicode-3.0,
           Unlicense
 
 # Only single licenses are allowed in this list.


### PR DESCRIPTION
## What

Added Unicode-3.0 to permitted license list.

## Why

It was needed by a [dependency](https://github.com/greenbone/management-console-connector/actions/runs/12142055483?pr=49).

## References

LEG-206


