### PR TITLE
Change: Sort licenses alphabetically in dependency review workflow

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -50,8 +50,8 @@ runs:
           PSF-2.0,
           Python-2.0,
           Python-2.0.1,
-          Unicode-DFS-2016,
           Unicode-3.0,
+          Unicode-DFS-2016,
           Unlicense
 
 # Only single licenses are allowed in this list.


### PR DESCRIPTION
## What

Sort licenses alphabetically in dependency review workflow.

## Why

The workflow fails with: 'Error: Invalid license(s) in allow-licenses: Unicode-3.0'

