### PR TITLE
Change: Remove Unicode-3.0 as it is not supported upstream

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -50,10 +50,16 @@ runs:
           PSF-2.0,
           Python-2.0,
           Python-2.0.1,
-          Unicode-3.0,
           Unicode-DFS-2016,
           Unlicense
 
+# Licenses that are not supported by dependency-review-action:
+# - Unicode-3.0,
+# - ...
+#
+# To be added after https://github.com/actions/dependency-review-action/pull/855
+# is merged upstream.
+#
 # Only single licenses are allowed in this list.
 # A combination of licenses like `License-A AND License-B`
 # is not supported. See:


### PR DESCRIPTION
## What

Removed Unicode-3.0.

## Why

Not supported by [dependency-review-action](https://github.com/actions/dependency-review-action/pull/855)

## References

https://github.com/actions/dependency-review-action/pull/855