### PR TITLE
Add: Allow MIT-CMU

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -44,6 +44,7 @@ runs:
           LGPL-3.0,
           LGPL-3.0-or-later,
           MIT,
+          MIT-CMU,
           MPL-1.1,
           MPL-2.0,
           OFL-1.1,


### PR DESCRIPTION
## What
Allow MIT-CMU

## Why

Needed by [pillow](https://github.com/python-pillow/Pillow), a dependency of pheme. Was flagged by Dependency review in https://github.com/greenbone/pheme/pull/941.

Was already approved before (See ticket below) but missing in the white list.

## References
LEG-197




