### PR TITLE
Fix: (Temp) set default poetry version to 1.8.0

### DIFF
--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -21,6 +21,7 @@ inputs:
     description: "Cache poetry and its dependencies by setting it to 'true'. Disabled by default."
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
+    default: "1.8.0"
   python-version:
     description: "Python version that should be installed and used."
     default: "3.10"


### PR DESCRIPTION
## What
 set default poetry version to 1.8.0
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
2.0.0 seems to break a major number of our workflows.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1372
<!-- Add identifier for issue tickets, links to other PRs, etc. -->
