### PR TITLE
Fix: (Temp) Use poetry 1.8.0 temporary until 2.0.0 is bug-free

### DIFF
--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -11,6 +11,7 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
+    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"


### PR DESCRIPTION
## What
Use poetry 1.8.0 temporary until 2.0.0 is bug-free
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
https://github.com/python-poetry/poetry/issues/9961
<!-- Describe why are these changes necessary? -->
