### PR TITLE
Remove: Unpin poetry version, by removing the default again

### DIFF
--- a/backport-pull-request/README.md
+++ b/backport-pull-request/README.md
@@ -55,7 +55,7 @@ workflow file of the backport action.
 | config         | TOML based configuration file for backporting pull requests | Optional (default is `backport.toml`) |
 | username       | GitHub user name to use for the backported commits          | Optional (by default github.actor is used) |
 | python-version | Python version to use for running the action                | Optional (default is `3.10`) |
-| poetry-version | Poetry version to use for running the action                | Optional (default is `1.8.0`) |
+| poetry-version | Poetry version to use for running the action                | Optional (default is `latest`) |
 
 ## TOML Configuration
 

--- a/backport-pull-request/action.yml
+++ b/backport-pull-request/action.yml
@@ -16,7 +16,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"

--- a/conventional-commits/README.md
+++ b/conventional-commits/README.md
@@ -51,7 +51,7 @@ jobs:
 |--------------|-----------|-|
 | token | GitHub token to create the pull request comments. | Optional (default is [`${{ github.token }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) |
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
-| poetry-version | Poetry version to use for running the action. | Optional (default is `1.8.0`) |
+| poetry-version | Poetry version to use for running the action. | Optional (default is `latest`) |
 | cache-poetry-installation | Cache poetry and its dependencies. | Optional (default is `"true"`) |
 | head-ref | End ref where to look for conventional commits. | Optional (default is`${{ github.event.pull_request.head.sha }}`). |
 | base-ref | Start ref where to look for conventional commits. | Optional (default is `${{ github.event.pull_request.base.sha }}`). |

--- a/conventional-commits/action.yml
+++ b/conventional-commits/action.yml
@@ -11,7 +11,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"

--- a/coverage-python/README.md
+++ b/coverage-python/README.md
@@ -26,7 +26,7 @@ jobs:
 |-------|-------------|-|
 | python-version | Python version that should be installed | Optional (default: "3.10") |
 | test-command | Command to run the unit tests | Optional (default: `"-m unittest"`)
-| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default `1.8.0`) |
+| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default `latest`) |
 | cache | Cache dependencies by setting it to `"true"`. | Optional |
 | cache-dependency-path | "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies. | Optional |
 | cache-poetry-installation | Cache poetry and its dependencies by setting it to `"true"`. | Optional |

--- a/coverage-python/action.yaml
+++ b/coverage-python/action.yaml
@@ -14,7 +14,6 @@ inputs:
     description: "Upload token for codecov.io. Required for private repositories."
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache:
     description: "Cache dependencies by setting it to 'true'."
   cache-dependency-path:

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -41,7 +41,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"

--- a/helm-version-upgrade/action.yml
+++ b/helm-version-upgrade/action.yml
@@ -42,7 +42,6 @@ inputs:
     default: "3.11"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"

--- a/lint-python/README.md
+++ b/lint-python/README.md
@@ -26,7 +26,7 @@ jobs:
 |--------------|-----------|-|
 | packages | Python packages to lint | Required |
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
-| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default `1.8.0` poetry version) |
+| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default `latest` poetry version) |
 | cache | Cache dependencies by setting it to `"true"`. Leave unset or set to an other string then `"true"` to disable the cache. | Optional |
 | cache-dependency-path | Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies. | Optional |
 | cache-poetry-installation | "Cache poetry and its dependencies. Default is `"true"`. Set to an other string then `"true"` to disable the cache." | Optional (default: `"true"`) |

--- a/lint-python/action.yaml
+++ b/lint-python/action.yaml
@@ -11,7 +11,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache:
     description: "Cache dependencies by setting it to 'true'. Leave unset or set to an other string then 'true' to disable the cache."
   cache-dependency-path:

--- a/mypy-python/README.md
+++ b/mypy-python/README.md
@@ -27,7 +27,7 @@ jobs:
 | packages | Python packages to check | Required |
 | mypy-arguments | Additional arguments to mypy | Optional |
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
-| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default `1.8.0` poetry version) |
+| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default `latest` poetry version) |
 | cache | Cache dependencies by setting it to `"true"`. Leave unset or set to an other string then `"true"` to disable the cache. | Optional |
 | cache-dependency-path | Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies. | Optional |
 | cache-poetry-installation | "Cache poetry and its dependencies. Default is `"true"`. Set to an other string then `"true"` to disable the cache." | Optional (default: `"true"`) |

--- a/mypy-python/action.yaml
+++ b/mypy-python/action.yaml
@@ -14,7 +14,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   install-dependencies:
     description: "Install project dependencies. Default is 'true'. Set to an other string then 'true' to not install the dependencies."
     default: "true"

--- a/oci-info/README.md
+++ b/oci-info/README.md
@@ -47,7 +47,7 @@ jobs:
 | compare-user              | User for the compare registry login.                                                                           | Optional |
 | compare-password          | Password for the compare registry login.                                                                       | Optional |
 | python-version            | Python version to use for running the action. Default is 3.11 .                                                | Optional |
-| poetry-version            | Use a specific poetry version. By default the `1.8.0` release is used.                                          | Optional |
+| poetry-version            | Use a specific poetry version. By default the `latest` release is used.                                        | Optional |
 | cache-poetry-installation | Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache. | Optional |
 
 ## Action Output

--- a/oci-info/action.yml
+++ b/oci-info/action.yml
@@ -51,7 +51,6 @@ inputs:
     default: "3.11"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"

--- a/poetry/README.md
+++ b/poetry/README.md
@@ -44,5 +44,5 @@ jobs:
 | cache | Cache dependencies by setting it to 'true'. Leave unset or set to an other string then 'true' to disable the cache. | Optional |
 | cache-dependency-path | Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies. See [https://github.com/actions/setup-python#caching-packages-dependencies](https://github.com/actions/setup-python#caching-packages-dependencies) for more details. | Optional |
 | cache-poetry-installation | Cache poetry and its dependencies by setting it to 'true'. | Optional. Disabled by default. |
-| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default is `1.8.0` version) |
+| poetry-version | Use a specific poetry version. By default the latest release is used. | Optional (default is `latest` version) |
 | python-version | Python version that should be installed and used. | Optional (default: "3.10") |

--- a/poetry/action.yaml
+++ b/poetry/action.yaml
@@ -21,7 +21,6 @@ inputs:
     description: "Cache poetry and its dependencies by setting it to 'true'. Disabled by default."
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   python-version:
     description: "Python version that should be installed and used."
     default: "3.10"

--- a/pr-conventional-commit-labeler/README.md
+++ b/pr-conventional-commit-labeler/README.md
@@ -72,7 +72,7 @@ jobs:
 |--------------|-----------|-|
 | token | GitHub token to add lebels to the pull request comments. | Optional (default is [`${{ github.token }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) |
 | python-version | Python version to use for running the action. | Optional (default is `3.10`) |
-| poetry-version | Poetry version to use for running the action. | Optional (default is `1.8.0`) |
+| poetry-version | Poetry version to use for running the action. | Optional (default is `latest`) |
 | cache-poetry-installation | Cache poetry and its dependencies. | Optional (default is `"true"`) |
 | configuration-toml| Name of the configuration file, must be relative to `github.workspace` | Required  |
 | pr | Number of the Pull Request (PR) | Optional (default is ${{ github.event.pull_request.number }} |

--- a/pr-conventional-commit-labeler/action.yml
+++ b/pr-conventional-commit-labeler/action.yml
@@ -10,7 +10,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"

--- a/trigger-workflow/action.yml
+++ b/trigger-workflow/action.yml
@@ -33,7 +33,6 @@ inputs:
     default: "3.10"
   poetry-version:
     description: "Use a specific poetry version. By default the latest release is used."
-    default: "1.8.0"
   cache-poetry-installation:
     description: "Cache poetry and its dependencies. Default is 'true'. Set to an other string then 'true' to disable the cache."
     default: "true"


### PR DESCRIPTION
## What
Unpin poetry version, by removing the default again


## Why
poetry 2.0.1 fixes our issues
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1374
Reverts #1311 #1314 #1315 
https://github.com/python-poetry/poetry/issues/9961
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


