### PR TITLE
Add new action for installing cgreen

### DIFF
--- a/install-cgreen/README.md
+++ b/install-cgreen/README.md
@@ -1,0 +1,25 @@
+# Install the cgreen testing framework
+
+GitHub Action to install the [cgreen](https://github.com/cgreen-devs/cgreen)
+testing framework into the current runner. The cgreen testing framework is
+intended for C and C++.
+
+## Use Case
+
+```yaml
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Instal cgreen"
+        uses: greenbone/actions/install-cgreen@v3
+```
+
+## Action Configuration
+
+| Input Variable | Description                                          | Default                                                            |
+| ---------------| -----------------------------------------------------| ------------------------------------------------------------------ |
+| version        | cgreen release version to use                        | `1.6.2`                                                            |
+| hash           | SHA256 hash of the downloaded cgreen release tarball | `fe6be434cbe280330420106bd5d667f1bc84ae9468960053100dbf17071036b9` |

--- a/install-cgreen/action.yml
+++ b/install-cgreen/action.yml
@@ -1,0 +1,44 @@
+name: "Install cgreen test framework"
+description: "Build and install a cgreen release from source"
+
+inputs:
+  hash:
+    description: "SHA256 hash of the downloaded cgreen archive."
+    default: "fe6be434cbe280330420106bd5d667f1bc84ae9468960053100dbf17071036b9"
+  version:
+    description: "Version of the release to download."
+    default: "1.6.2"
+
+branding:
+  icon: "package"
+  color: "green"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Install dependencies"
+      shell: bash
+      run: |
+        apt-get update && \
+        apt-get install -y --no-install-recommends  --no-install-suggests \
+            build-essential \
+            ca-certificates \
+            cmake \
+            curl \
+            gcc \
+            && rm -rf /var/lib/apt/lists/*
+    - name: "Install dependencies"
+      shell: bash
+      run: curl -sSL -o cgreen.tar.gz https://github.com/cgreen-devs/cgreen/archive/refs/tags/${{ inputs.version }}.tar.gz
+    - name: "Validate cgreen archive"
+      shell: bash
+      run: |
+        echo "${{ inputs.hash }} cgreen.tar.gz" | sha256sum -c -
+    - name: "Build and install cgreen"
+      shell: bash
+      run: |
+        tar -xzf cgreen.tar.gz
+        cd cgreen-*
+        cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+        cmake --build build -j$(nproc) -- install
+        ldconfig


### PR DESCRIPTION

## What

Add a new reusable action to install cgreen for running tests in our C projects.

## Why

cgreen wont be available in current Debian versions via deb packages. Therefore we have to install it manually from source via a release tarball.


