### PR TITLE
Add: Add ZPL-2.1 to allowed licenses in dependency-review action

### DIFF
--- a/dependency-review/action.yml
+++ b/dependency-review/action.yml
@@ -53,7 +53,8 @@ runs:
           Python-2.0.1,
           Unicode-DFS-2016,
           Unlicense,
-          Zlib
+          Zlib,
+          ZPL-2.1
 
 # Licenses that are not supported by dependency-review-action:
 # - Unicode-3.0,


### PR DESCRIPTION
## What

Add ZPL-2.1 to list of allowed licenses in dependency-review action.

## Why

The license is allowed and we want to use it.


