### PR TITLE
Update actions/cache to 4.2.2 to fix error

### DIFF
--- a/pipx/action.yml
+++ b/pipx/action.yml
@@ -89,7 +89,7 @@ runs:
       # cache venv only if an application will be installed and the user requested caching and no python path is set
       if: inputs.install && inputs.cache == 'true' && !inputs.python-path
       id: cache
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ${{ steps.settings.outputs.venvs }}/${{ inputs.install }}
         key: python-${{ steps.python.outputs.python-version }}-pipx-venv-${{ inputs.install }}-${{ inputs.install-version || 'latest' }}


### PR DESCRIPTION


## What
Update actions/cache to 4.2.2 to fix error
## Why

gvm-tools has an issue with stating an outdated now unsupported actions/cache version is used. Try to fix this issue by updating to the latest release.

For me there seems to be something wrong with our used version. See new commit https://github.com/actions/cache/commit/1bd1e32a3bdc45362d1e726936510720a7c30a57 And old commit https://github.com/actions/cache/commit/1bd1e32a3bdc45362d1e726936510720a7c30a57

gvm-tools CI has an issue

## References
https://github.com/greenbone/gvm-tools/actions/runs/13757012144/job/38465960419?pr=1195


