### PR TITLE
Add a new action for determining the release version

### DIFF
--- a/release-version/README.md
+++ b/release-version/README.md
@@ -1,0 +1,66 @@
+# Release Version
+
+GitHub Action to determine the release version
+
+## Example
+
+```yml
+name: Determine Release version
+
+on:
+  workflow_dispatch:
+      release-type:
+        type: choice
+        description: What kind of release do you want to do?
+        options:
+          - patch
+          - minor
+          - major
+          - release-candidate
+          - alpha
+          - beta
+
+jobs:
+  check:
+    name: Determine Release Version
+    runs-on: ubuntu-latest
+    steps:
+        - uses: greenbone/actions/release-version@v3
+          id: release-version
+          with:
+            release-type: ${{ inputs.release-type }}
+        - name: Print release type and ref
+          run: |
+            echo ${{ steps.release-version.outputs.last-release-version }}
+            echo ${{ steps.release-version.outputs.last-release-version-major }}
+            echo ${{ steps.release-version.outputs.last-release-version-minor }}
+            echo ${{ steps.release-version.outputs.last-release-version-patch }}
+            echo ${{ steps.release-version.outputs.release-version }}
+            echo ${{ steps.release-version.outputs.release-version-major }}
+            echo ${{ steps.release-version.outputs.release-version-minor }}
+            echo ${{ steps.release-version.outputs.release-version-patch }}
+```
+
+## Action Configuration
+
+| Input Variable    | Description                                                           |                             |
+| ----------------- | --------------------------------------------------------------------- | --------------------------- |
+| python-version    | Python version to use for running the code                            | Optional                    |
+| release-type      | Type of the release.                                                  | Required                    |
+| release-version   | A release version to use. Overrides release-type                      | Optional                    |
+| release-series    | A release series to use.                                              | Optional                    |
+| versioning-scheme | The versioning scheme to use for the release. Either pep440 or semver | Optional. Default is pep440 |
+| git-tag-prefix    | The prefix for the git tags                                           | Optional. Default is 'v'    |
+
+## Output Arguments
+
+| Output Variable            | Description                           |
+| -------------------------- | ------------------------------------- |
+| last-release-version       | The last release version              |
+| last-release-version-major | The major version of the last release |
+| last-release-version-minor | The minor version of the last release |
+| last-release-version-patch | The patch version of the last release |
+| release-version            | The determined version of the release |
+| release-version-major      | The major version of the release      |
+| release-version-minor      | The minor version of the release      |
+| release-version-patch      | The patch version of the release      |

--- a/release-version/action.yml
+++ b/release-version/action.yml
@@ -1,0 +1,89 @@
+name: "Determine Release Version"
+author: "Björn Ricks <bjoern.ricks@greenbone.net>"
+description: "An action to determine the release version based on the release type and the current version"
+
+inputs:
+  python-version:
+    description: "Python version to use"
+  release-type:
+    description: "The release type to determine the version for"
+    required: true
+  git-tag-prefix:
+    description: "The prefix for the git tags"
+    required: false
+    default: "v"
+  release-version:
+    description: "The release version to use. Overrides release-type."
+    required: false
+  release-series:
+    description: "An optional release series to use"
+    required: false
+  versioning-scheme:
+    description: "What versioning scheme should be used for the release? Supported: 'semver' and 'pep440'. Default: pep440"
+    default: "pep440"
+
+outputs:
+  last-release-version:
+    description: "The last release version"
+    value: ${{ steps.release-versions.outputs.last_release_version }}
+  last-release-version-major:
+    description: "The major version of the last release"
+    value: ${{ steps.release-versions.outputs.last_release_version_major }}
+  last-release-version-minor:
+    description: "The minor version of the last release"
+    value: ${{ steps.release-versions.outputs.last_release_version_minor }}
+  last-release-version-patch:
+    description: "The patch version of the last release"
+    value: ${{ steps.release-versions.outputs.last_release_version_patch }}
+  release-version:
+    description: "The release version"
+    value: ${{ steps.release-versions.outputs.release_version }}
+  release-version-major:
+    description: "The major version of the release"
+    value: ${{ steps.release-versions.outputs.release_version_major }}
+  release-version-minor:
+    description: "The minor version of the release"
+    value: ${{ steps.release-versions.outputs.release_version_minor }}
+  release-version-patch:
+    description: "The patch version of the release"
+    value: ${{ steps.release-versions.outputs.release_version_patch }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup pontos
+      uses: greenbone/actions/uv@v3
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache-suffix: pontos
+        install: pontos
+    - name: Parse release-type
+      run: |
+        case ${{ inputs.release-type }} in
+          alpha | beta | calendar | major | minor | patch | release-candidate)
+            ARGS="--release-type ${{ inputs.release-type }}"
+            ;;
+          *)
+            ARGS="--release-type patch"
+            ;;
+        esac
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
+    - name: Parse release-version if set (overwrite release-type)
+      if: ${{ inputs.release-version }}
+      run: |
+        ARGS="--release-version ${{ inputs.release-version }}"
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
+    - name: Parse release-series
+      if: ${{ inputs.release-series }}
+      run: |
+        ARGS="${ARGS} --release-series ${{ inputs.release-series }}"
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
+    - name: Determine release versions
+      id: release-versions
+      run: |
+        pontos-release show ${{ env.ARGS }} --output-format env --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
+        pontos-release show ${{ env.ARGS }} --output-format github-action --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
+      shell: bash


### PR DESCRIPTION


## What

Add a new action for determining the release version

## Why

The action allows to determine the release version before actually making the release. With this change it will possible to split up making the release into:
* determine the release type
* get the release version
* create the release
* sign the release

with possible additional steps in between.