### PR TITLE
Add changelog and last-release-version inputs to release action

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -61,6 +61,8 @@ You can alternatively set an explicit `release-version`. It will overwrite the `
 | next-version         | Set an explicit version that should be used after the release. Leave empty for determining the next version automatically. Set to `'false'` for not updating the version after a release. |                                                  |
 | github-pre-release   | Set to `'true'`` to enforce uploading the release to GitHub as a pre-release                                                                                                              |                                                  |
 | repository           | GitHub repository (owner/name) to create the release for.                                                                                                                                 | Optional (default is `${{ github.repository }}`) |
+| changelog            | A path to a changelog file. If not set a changelog will be generated.                                                                                                                     | Optional                                         |
+| last-release-version | The last release version. If not set, it will be detected automatically.                                                                                                                  | Optional                                         |
 
 ## Output Arguments
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -62,6 +62,12 @@ inputs:
   repository:
     description: "GitHub repository (owner/name) to create the release for."
     default: ${{ github.repository }}
+  changelog:
+    description: "Optional path to a changelog file. If not set a changelog will be generated."
+    required: false
+  last-release-version:
+    description: "The last release version. If not set, it will be detected automatically."
+    required: false
 
 outputs:
   release-version:
@@ -144,6 +150,18 @@ runs:
       if: ${{ inputs.release-series }}
       run: |
         ARGS="${ARGS} --release-series ${{ inputs.release-series }}"
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
+    - name: Use changelog file
+      if: ${{ inputs.changelog }}
+      run: |
+        ARGS="${ARGS} --changelog ${{ inputs.changelog }}"
+        echo "ARGS=${ARGS}" >> $GITHUB_ENV
+      shell: bash
+    - name: Use last release version
+      if: ${{ inputs.last-release-version }}
+      run: |
+        ARGS="${ARGS} --last-release-version ${{ inputs.last-release-version }}"
         echo "ARGS=${ARGS}" >> $GITHUB_ENV
       shell: bash
     - name: Update project files


### PR DESCRIPTION

## What

Add changelog and last-release-version inputs to release action

## Why

Allow to pass a path to a changelog file and the last release version to the release action. With this change it will possible to generate a changelog outside of the release action and to use the release-version action beforehand of the release action.

Supports and requires https://github.com/greenbone/pontos/releases/tag/v25.3.0
