### PR TITLE
Deprecated venv outputs of setup-python

### DIFF
--- a/lock-branch/action.yaml
+++ b/lock-branch/action.yaml
@@ -27,7 +27,6 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python and pontos
-      id: virtualenv
       uses: greenbone/actions/setup-pontos@v3
     - name: lock/unlock?
       run: |
@@ -44,7 +43,6 @@ runs:
       # in case of blubber input let the branch be unlocked!
     - name: Prepare release and store the version
       run: |
-        source ${{ steps.virtualenv.outputs.activate }}
         pontos-github-script pontos.github.scripts.lock-branch ${{ inputs.repository }} ${{ inputs.branch }} ${{ env.LOCK_OPT }}
       shell: bash
       env:

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -117,7 +117,6 @@ runs:
         token: ${{ inputs.github-user-token }}
     - name: Set up Python and pontos
       uses: greenbone/actions/setup-pontos@v3
-      id: virtualenv
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -199,7 +198,6 @@ runs:
     - name: Create automatic release
       id: release
       run: |
-        source ${{ steps.virtualenv.outputs.activate }}
         pontos-release create ${{ env.ARGS }} --repository ${{ inputs.repository }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
       env:

--- a/setup-pontos/README.md
+++ b/setup-pontos/README.md
@@ -21,13 +21,13 @@ jobs:
 
 ## Action Configuration
 
-|Input Variable|Description| |
-|--------------|-----------|-|
-| python-version | Python version to use for running the action. | Optional (default is `3.10`) |
-| virtualenv-path |  | Deprecated and will be ignored. |
-| cache-key |  | Deprecated and will be ignored. |
+| Input Variable  | Description                                   |                                 |
+| --------------- | --------------------------------------------- | ------------------------------- |
+| python-version  | Python version to use for running the action. | Optional (default is `3.10`)    |
+| virtualenv-path |                                               | Deprecated and will be ignored. |
+| cache-key       |                                               | Deprecated and will be ignored. |
 
-|Output Variable|Description|
-|---------------|-----------|
-| virtualenv-path | Path to the created virtual Python environment |
-| activate | Path to the activate environment script |
+| Output Variable | Description                                    |                            |
+| --------------- | ---------------------------------------------- | -------------------------- |
+| virtualenv-path | Path to the created virtual Python environment | Deprecated. Will be empty. |
+| activate        | Path to the activate environment script        | Deprecated. Will be empty. |

--- a/setup-pontos/action.yml
+++ b/setup-pontos/action.yml
@@ -40,12 +40,6 @@ runs:
         python-version: ${{ steps.pontos.outputs.installed == 'false' && inputs.python-version || '' }}
         install: ${{  steps.pontos.outputs.installed == 'false' && 'pontos' || '' }}
         cache: "true"
-    - name: Virtual Environment
-      id: virtualenv
-      run: |
-        echo "path=${{ steps.pipx.outputs.venvs }}/pontos" >> $GITHUB_OUTPUT
-        echo "activate=${{ steps.pipx.outputs.venvs }}/pontos/bin/activate" >> $GITHUB_OUTPUT
-      shell: bash
     - name: Print pontos version
       run: |
         pontos --version


### PR DESCRIPTION


## What

Deprecated venv outputs of setup-python

## Why
How pontos is installed should be an implementation details. Workflows should not rely on the existence of some venv and only on pontos being in the PATH.

## References
https://github.com/greenbone/gsa/actions/runs/13852855211/job/38763241273


