### PR TITLE
Add: cancellation of running CI jobs on new commit

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,11 @@
 name: Auto-merge sqash
+
 on: pull_request_target
     
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '33 15 * * 5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
     - cron: '33 15 * * 5'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.language }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,10 @@ name: Conventional Commits
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,10 @@ name: Dependency Review
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         type: string
         description: Set an explicit version (without leading v), that will overwrite release-type. Fails if version is not semver compliant.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Actions

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   SBOM-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-doc-coverage.yml
+++ b/.github/workflows/test-doc-coverage.yml
@@ -16,6 +16,10 @@ on:
       - "doc-coverage-clang/**"
       - ".github/workflows/test-doc-coverage.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-doc-cov-clang:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-download-artifacts-test-workflow.yml
+++ b/.github/workflows/test-download-artifacts-test-workflow.yml
@@ -3,6 +3,10 @@ name: To be Triggered Upload Artifacts Test Workflow
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   echo:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-download-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-hashsums.yml
+++ b/.github/workflows/test-hashsums.yml
@@ -1,4 +1,4 @@
-name: Test Python Actions
+name: Test sha256 Hashsum creation
 
 on:
   push:

--- a/.github/workflows/test-hashsums.yml
+++ b/.github/workflows/test-hashsums.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-creating-sha256sums-file:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-is-latest-tag.yml
+++ b/.github/workflows/test-is-latest-tag.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-older-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install-poetry:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-signature.yml
+++ b/.github/workflows/test-signature.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-creating-signature-file:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-signature.yml
+++ b/.github/workflows/test-signature.yml
@@ -1,4 +1,4 @@
-name: Test Python Actions
+name: Test Signature Creation
 
 on:
   push:

--- a/.github/workflows/test-trigger-workflow-failing-workflow.yml
+++ b/.github/workflows/test-trigger-workflow-failing-workflow.yml
@@ -3,6 +3,10 @@ name: To Be Triggered Failing Test Workflow
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   echo:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-trigger-workflow-long-running-workflow.yml
+++ b/.github/workflows/test-trigger-workflow-long-running-workflow.yml
@@ -3,6 +3,10 @@ name: To Be Triggered Long Running Test Workflow
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   wait:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-trigger-workflow-test-workflow.yml
+++ b/.github/workflows/test-trigger-workflow-test-workflow.yml
@@ -3,6 +3,10 @@ name: To be Triggered Test Workflow
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   echo:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-trigger-workflow.yml
+++ b/.github/workflows/test-trigger-workflow.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-timeout:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-backport-pull-request-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## What

Add cancellation of running CI jobs on new commit in same ref
to all workflows.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

We usually don't need to continue running old jobs when a new commit comes in that starts the same jobs again.

This saves us some running time and resources.

<!-- Describe why are these changes necessary? -->

## References
see DEVOPS-1538

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [NA] Tests