### PR TITLE
Fix: wrong input description of inventory and inventory-path

### DIFF
--- a/deploy-env/README.md
+++ b/deploy-env/README.md
@@ -93,7 +93,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_KEY }}
           ssh-known-hosts: ${{ vars.KNOWN_HOSTS_FILE }}
-          inventory: 192.168.0.1,
+          inventory-path: 192.168.0.1,
           user: root
           vars: |
             copy: my_deployment_data_folder
@@ -110,10 +110,10 @@ jobs:
 |--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
 | ssh-key            | SSH key file data. Optional if file exist.                                                                                                                                            | Required |
 | vars               | Extra vars like passwords that can not be in the inventory file or the cmd command to run on the node. As yaml. Optional if file exist.                                               | Required |
-| inventory          | Inventory file data as yaml, or a comma(,) seperated list of IP/Domain names, if it is a just one IP/Domain it needs a comma at the end. Optional if file exist.                      | Required |
+| inventory          | Inventory file data as yaml. Optional if file exist.                      | Required |
 | ssh-known-hosts    | SSH fingerprints for dev servers. Optional if file exist.                                                                                                                             | Optional |
-| user               | Username used for login. ONLY set this if you inventory data is a comma(,) seperated list of IP/Domain names. If not please put the username in the inventory file. Default is empty. | Optional |
-| inventory-path     | Inventory file path. Default is inventory.yml.                                                                                                                                        | Optional |
+| user               | Username used for login. ONLY set this if you inventory-path is a comma(,) seperated list of IP/Domain names. If not please put the username in the inventory file. Default is empty. | Optional |
+| inventory-path     | Inventory file path, or a comma(,) seperated list of IP/Domain names, if it is a just one IP/Domain it needs a comma at the end. Default is inventory.yml.                                                                                                                                        | Optional |
 | ssh-key-path       | SSH key file path. Default is ssh.key                                                                                                                                                 | Optional |
 | vars-path          | Vars file path. Default is vars.yml                                                                                                                                                   | Optional |
 | limit-hosts        | Limit deployment to hosts. Default is all.                                                                                                                                            | Optional |

--- a/deploy-env/action.yml
+++ b/deploy-env/action.yml
@@ -3,12 +3,12 @@ description: "Deploy a dev environment on a server."
 
 inputs:
   inventory:
-    description: "Inventory file data as yaml, or a comma(,) seperated list of IP/Domain names, if it is a just one IP/Domain it needs a comma at the end. Optional if file exist."
+    description: "Inventory file data as yaml. Optional if file exist."
   inventory-path:
-    description: "Inventory file path. Default is inventory.yml."
+    description: "Inventory file path, or a comma(,) seperated list of IP/Domain names, if it is a just one IP/Domain it needs a comma at the end. Default is inventory.yml."
     default: "inventory.yml"
   user:
-    description: "Username used for login. ONLY set this if you inventory data is a comma(,) seperated list of IP/Domain names. If not please put the username in the inventory file. Default is empty."
+    description: "Username used for login. ONLY set this if you inventory-path is a comma(,) seperated list of IP/Domain names. If not please put the username in the inventory file. Default is empty."
   ssh-key:
     description: "SSH key file data. Optional if file exist."
   ssh-key-path:

--- a/deploy-env/run.yml
+++ b/deploy-env/run.yml
@@ -5,8 +5,15 @@
   any_errors_fatal: true
   ignore_errors: false
   tasks:
+    - name: Check if vars file exist
+      ansible.builtin.stat:
+        path: "{{ base_dir }}/{{ vars_path }}"
+      register: check_vars
+      delegate_to: localhost
+
     - name: Load vars
       ansible.builtin.include_vars: "{{ base_dir }}/{{ vars_path }}"
+      when: check_vars.stat.exists
 
     - name: Deployment environment
       block:


### PR DESCRIPTION
## What
[Fix: wrong input description of inventory and inventory-path](https://github.com/greenbone/actions/commit/21f25f7acb197ac9854372839be717d66946b8f3)
[Change: make vars file optional](https://github.com/greenbone/actions/commit/b050d3fb36a61ac8e3954149373eb8ae88e73dd2)
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
The description of  inventory and inventory-path was mixed.
The vars file can be optional, because all statements like copy, env and cmd are already optional and can be placed in the inventory file.
<!-- Describe why are these changes necessary? -->

## References
None



