### PR TITLE
Allow to define working-directory for uv

### DIFF
--- a/uv/README.md
+++ b/uv/README.md
@@ -41,15 +41,16 @@ jobs:
 
 ## Action Configuration
 
-| Input Variable        | Description                                   |                             |
-| --------------------- | --------------------------------------------- | --------------------------- |
-| python-version        | Python version to use for running the action. | Optional                    |
-| install               | The package to install from PyPI              | Optional                    |
-| enable-cache          | Enable caching                                | Optional (default: true)    |
-| cache-dependency-glob | Glob pattern to match dependencies to cache.  | Optional. Default: ""       |
-| cache-suffix          | Suffix to append to the cache key             | Optional                    |
-| cache-local-path      | Path to the local cache                       | Optional                    |
-| uv-version            | The version of uv to install and use          | Optional. Default is latest |
+| Input Variable        | Description                                           |                             |
+| --------------------- | ----------------------------------------------------- | --------------------------- |
+| python-version        | Python version to use for running the action.         | Optional                    |
+| install               | The package to install from PyPI                      | Optional                    |
+| enable-cache          | Enable caching                                        | Optional (default: true)    |
+| cache-dependency-glob | Glob pattern to match dependencies to cache.          | Optional. Default: ""       |
+| cache-suffix          | Suffix to append to the cache key                     | Optional                    |
+| cache-local-path      | Path to the local cache                               | Optional                    |
+| uv-version            | The version of uv to install and use                  | Optional. Default is latest |
+| working-directory     | The working directory. Where to find the config files | Optional                    |
 
 | Output Variable | Description                    |
 | --------------- | ------------------------------ |

--- a/uv/action.yml
+++ b/uv/action.yml
@@ -27,6 +27,12 @@ inputs:
   uv-version:
     description: "The version of uv"
     required: false
+  working-directory:
+    description: |
+      "The working directory. This controls where we look for pyproject.toml, "
+      "uv.toml and .python-version files which are used to determine the "
+      "version of uv and python to install."
+    required: false
 
 outputs:
   version:
@@ -62,6 +68,7 @@ runs:
         cache-suffix: ${{ inputs.cache-suffix }}
         cache-local-path: ${{ inputs.cache-local-path }}
         version: ${{ inputs.uv-version }}
+        working-directory: ${{ inputs.working-directory }}
     - name: uv version
       id: version
       run: |


### PR DESCRIPTION


## What
Allow to define working-directory for uv

## Why

Allow to define where to run uv to find the pyproject.toml and other config files.
## References

https://github.com/greenbone/qm-gmp-robot/actions/runs/15877287316


