### PR TITLE
Add new action to create a multi-arch container image

### DIFF
--- a/create-multi-arch-container-image/README.md
+++ b/create-multi-arch-container-image/README.md
@@ -1,0 +1,86 @@
+# Create multi arch container image
+
+A action to create a multi arch container image to and upload it to one or more
+container registries.
+
+Requires the single-arch images are already pushed to the registry and existing
+login in to the registries.
+
+> [!NOTE]
+> For uploading OCI images to the GitHub Container Registry the annotations need
+> to be index annotations.
+
+> [!TIP]
+> The action can also be used to tag a single image
+
+## Examples
+
+Create a new multi arch image from two existing images and upload it to two
+different registries.
+
+```yml
+name: Create multi arch image
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Create multi arch image
+        uses: greenbone/actions/create-multi-arch-container-image@v3
+        with:
+          tags: |
+            ghcr.io/greenbone/some-service:latest
+            some-registry.org/greenbone/some-service:1.2.3
+          annotations: |
+            index:org.opencontainers.image.description=Some Service
+            index:org.opencontainers.image.licenses=AGPL-3.0
+          digests: |
+            ghcr.io/greenbone/some-service@sha256:12345
+            ghcr.io/greenbone/some-service@sha256:54321
+```
+
+Tag an existing container image as latest by its digest.
+
+```yml
+name: Tag latest container image
+
+on:
+  workflow_dispatch:
+    inputs:
+      digest:
+        type: string
+        required: true
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Tag container image
+        uses: greenbone/actions/create-multi-arch-container-image@v3
+        with:
+          tags: |
+            ghcr.io/greenbone/some-service:latest
+          annotations: |
+            index:org.opencontainers.image.description=Some Service
+            index:org.opencontainers.image.licenses=AGPL-3.0
+          digests: |
+            ghcr.io/greenbone/some-service@${{ inputs.digest }}
+```
+
+## Inputs
+
+| Name        | Description                                                                            |                          |
+| ----------- | -------------------------------------------------------------------------------------- | ------------------------ |
+| digests     | New line separated list of container image digests to merge into the multi-arch image. | Required                 |
+| tags        | New line separated list of tags for the created multi-arg image.                       | Required                 |
+| annotations | New line separated list of annotations for the created multi-arch image.               | Optional                 |
+| inspect     | Whether to display inspect information of the created multi-arch image                 | Optional (default: true) |
+
+## Output
+
+| Output Variable | Description                                 |
+| --------------- | ------------------------------------------- |
+| digest          | The digest of the created multi-arch image. |

--- a/create-multi-arch-container-image/action.yml
+++ b/create-multi-arch-container-image/action.yml
@@ -1,0 +1,74 @@
+name: "Create a Multi-Arch Container Image and Push to Registry"
+
+description: |
+  "Create and push a multi-architecture container image to one or more container registries. "
+  "Requires that the single-arch images are already pushed to the registry and "
+  "you are logged in to the registries."
+
+inputs:
+  digests:
+    description: "List of digests of the single-arch images separated by new lines"
+    required: true
+    default: ""
+  tags:
+    description: "List of tags for the multi-arch image separated by new lines"
+    required: true
+    default: ""
+  annotations:
+    description: "List of annotations for the multi-arch image separated by new lines"
+    required: false
+    default: ""
+  inspect:
+    description: "Whether to inspect the created multi-arch image"
+    required: false
+    default: "true"
+
+branding:
+  icon: "package"
+  color: "green"
+
+outputs:
+  digest:
+    description: "The digest of the created multi-arch image"
+    value: ${{ steps.image.outputs.digest }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+    - name: Create manifest list and push
+      shell: bash
+      id: image
+      run: |
+        set +e
+
+        IFS=$'\n' read -r -d '' -a tags <<< "$(printf '%s\n' '${{ inputs.tags }}' | sort -u)"
+        IFS=$'\n' read -r -d '' -a digests <<< "$(printf '%s\n' '${{ inputs.digests }}' | sort -u)"
+        IFS=$'\n' read -r -d '' -a annotations <<< "$(printf '%s\n' '${{ inputs.annotations }}' | sort -u)"
+
+        echo "Tags: ${tags[@]}"
+        echo "Digests: ${digests[@]}"
+        echo "Annotations: ${annotations[@]}"
+
+        echo "tag=${tags[0]}" >> $GITHUB_OUTPUT
+
+        set -e -o pipefail
+
+        IFS=$'\n'; a=(); for l in "${annotations[@]}"; do a+=(--annotation "$l"); done;
+        IFS=$'\n'; t=(); for l in "${tags[@]}"; do t+=(--tag "$l") ; done;
+
+        echo "Used arguments: ${a[@]} ${t[@]} ${digests[@]}"
+
+        out=$(docker buildx imagetools create --progress rawjson "${a[@]}" "${t[@]}" "${digests[@]}" 2>&1)
+
+        digest=$(echo "$out" | tail -1 | jq -r '.vertexes[0].digest')
+        echo "Digest: $digest"
+        echo "digest=$digest" >> $GITHUB_OUTPUT
+
+    - name: Inspect image
+      if: ${{ inputs.inspect == 'true' }}
+      shell: bash
+      run: |
+        docker buildx imagetools inspect ${{ steps.image.outputs.tag }}


### PR DESCRIPTION

## What

A simplified and more flexible solution to the container-multi-arch-manifest action. It allows for uploading to multiple registries. It doesn't log in to an existing registry and does also not create a signature.

In future the container-multi-arch-manifest action could possibly use this action internally.


## Why

Don't stick to a single registry and don't create signatures. Just merging one or more images.

## References

https://jira.greenbone.net/browse/GEA-1139


