### PR TITLE
Add action to trigger a harbor replication policy

### DIFF
--- a/trigger-harbor-replication/README.md
+++ b/trigger-harbor-replication/README.md
@@ -1,0 +1,31 @@
+# Trigger Harbor Replication Policy
+
+An action to trigger a harbor replication policy.
+
+## Example
+
+```yml
+name: Trigger harbor replication
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: greenbone/actions/trigger-harbor-replication@v3
+        with:
+          registry: ${{ vars.HARBOR_REGISTRY }}
+          user: ${{ secret.HARBOR_USER }}
+          token: ${{ secret.HARBOR_TOKEN }}
+```
+
+## Inputs
+
+| Name     | Description                                        |                          |
+| -------- | -------------------------------------------------- | ------------------------ |
+| registry | The URL of the Harbor registry (without https://)  | Required                 |
+| token    | The token to authenticate with the Harbor registry | Required                 |
+| user     | The user to authenticate with the Harbor registry  | Required                 |
+| policy   | The ID of the policy to trigger                    | Optional (default: "1"). |

--- a/trigger-harbor-replication/action.yml
+++ b/trigger-harbor-replication/action.yml
@@ -1,0 +1,38 @@
+name: "Trigger Harbor Replication"
+
+description: "Trigger a replication in a Harbor registry."
+
+inputs:
+  registry:
+    description: "The URL of the Harbor registry (without https://)"
+    required: true
+  token:
+    description: "The token to authenticate with the Harbor registry"
+    required: true
+  user:
+    description: "The user to authenticate with the Harbor registry"
+    required: true
+  policy-id:
+    description: "The replication policy ID to trigger"
+    required: false
+    default: "1"
+
+branding:
+  icon: "package"
+  color: "green"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Trigger harbor replication
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.token }}" ]; then
+          echo "::error::Registry replication token is missing"
+          exit 1
+        fi
+        curl --fail-with-body -X POST \
+          https://${{ inputs.registry }}/api/v2.0/replication/executions \
+          -u '${{ inputs.user }}:${{ inputs.token }}' \
+          -H "Content-Type: application/json" \
+          -d '{"policy_id": ${{ inputs.policy-id }}}'


### PR DESCRIPTION
## What

Add action to trigger a harbor replication policy

## Why

This job is used in some workflows to trigger replicating all uploaded images to our public container registry. It just got extracted into an action to hide implementation details.