### PR TITLE
Add new actions for uploading and downloading digests

### DIFF
--- a/download-digest/README.md
+++ b/download-digest/README.md
@@ -1,0 +1,74 @@
+# Download a Digest
+
+This action downloads container image digest files as artifacts and determines
+their contents. Because it is not possible to use outputs in a matrix strategy,
+this action can be used to collect the digests of multiple images built in
+parallel jobs.
+
+## Example
+
+```yml
+name: Create Images by Digest
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        arch:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Create Image
+        uses: greenbone/actions/container-build-push-by-digest@v3
+        id: build
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            registry.org/foo/${{ github.event.repository.name }}
+          labels: |
+            org.opencontainers.image.description=Some Service
+            org.opencontainers.image.licenses=AGPL-3.0
+          dockerfile: ./Dockerfile
+          context: ./build
+          platforms: ${{ matrix.arch }}
+          build-args: |
+            FOO=bar
+            LOREM=ipsum
+      - name: Upload Digest
+        uses: greenbone/actions/upload-digest@v3
+        with:
+          name: digests-${{ matrix.arch }}
+          digest: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+
+  download:
+    needs:
+      - build
+    runs-on: "ubuntu-latest"
+    name: Download and display digests
+    jobs:
+      - name: Download digests
+        id: download
+        uses: greenbone/actions/download-digest@v3
+        with:
+          pattern: digests-*
+      - name: Display digests
+        run: |
+          echo "${{ steps.download.outputs.digests }}
+```
+
+## Inputs
+
+| Name    | Description                                                                 |          |
+| ------- | --------------------------------------------------------------------------- | -------- |
+| path    | The path to download the digest files to. Default is a temporary directory. | Optional |
+| pattern | The pattern to match digest files. Default is 'digests-*'.                  | Optional |
+
+## Output
+
+| Output Variable | Description                                  |
+| --------------- | -------------------------------------------- |
+| digest          | The downloaded digests separated by newline. |

--- a/download-digest/action.yml
+++ b/download-digest/action.yml
@@ -1,0 +1,44 @@
+name: Download a Digest
+
+description: |
+  "Downloads container image digest files as artifacts and determines their "
+  "contents. Because it is not possible to use outputs in a matrix strategy, "
+  "this action can be used to collect the digests of multiple images built in "
+  "parallel jobs."
+
+inputs:
+  path:
+    description: "The path to download the digest files to. Default is a temporary directory."
+    required: false
+    default: "${{ runner.temp }}/digests"
+  pattern:
+    description: "The pattern to match digest files. Default is 'digests-*'."
+    required: false
+    default: "digests-*"
+
+outputs:
+  digests:
+    description: |
+      "The combined contents of all downloaded digest files. Separated by "
+      "newlines."
+    value: ${{ steps.digests.outputs.digests }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      with:
+        path: ${{ inputs.path }}
+        pattern: ${{ inputs.pattern }}
+        merge-multiple: true
+
+    - name: Determine digests
+      id: digests
+      shell: bash
+      run: |
+        {
+          echo 'digests<<EOF' >> $GITHUB_OUTPUT
+          cat "${{ inputs.path }}"/* >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+        }

--- a/upload-digest/README.md
+++ b/upload-digest/README.md
@@ -1,0 +1,65 @@
+# Upload a Digest
+
+This action uploads a container image digest file as an artifact.
+
+## Example
+
+```yml
+name: Create Images by Digest
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        arch:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Create Image
+        uses: greenbone/actions/container-build-push-by-digest@v3
+        id: build
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            registry.org/foo/${{ github.event.repository.name }}
+          labels: |
+            org.opencontainers.image.description=Some Service
+            org.opencontainers.image.licenses=AGPL-3.0
+          dockerfile: ./Dockerfile
+          context: ./build
+          platforms: ${{ matrix.arch }}
+          build-args: |
+            FOO=bar
+            LOREM=ipsum
+      - name: Upload Digest
+        uses: greenbone/actions/upload-digest@v3
+        with:
+          name: digests-${{ matrix.arch }}
+          digest: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+
+  download:
+    needs:
+      - build
+    runs-on: "ubuntu-latest"
+    name: Download and display digests
+    jobs:
+      - name: Download digests
+        id: download
+        uses: greenbone/actions/download-digest@v3
+        with:
+          pattern: digests-*
+      - name: Display digests
+        run: |
+          echo "${{ steps.download.outputs.digests }}
+```
+
+## Inputs
+
+| Name   | Description                                                                                  |          |
+| ------ | -------------------------------------------------------------------------------------------- | -------- |
+| digest | The digest of the container image to upload (should include the image name).                 | Required |
+| name   | The name of the artifact to create. Should fit to the pattern of the download-digest action. | Required |

--- a/upload-digest/action.yml
+++ b/upload-digest/action.yml
@@ -1,0 +1,28 @@
+name: Upload a Digest
+
+description: "Uploads a container image digest file as an artifact."
+
+inputs:
+  digest:
+    description: "The digest of the container image to upload (should include the image name)."
+    required: true
+  name:
+    description: "The name of the artifact to create."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        echo "${{ inputs.digest }}" > "${{ runner.temp }}/digests/${{ inputs.name }}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1


### PR DESCRIPTION
## What

Add new actions for uploading and downloading digests

## Why

Add an action to allow passing container image digests when using parallel builds via matrix strategy. In that case outputs can't be used when the pushed images digests need to be passed to a following workflow.

## References

https://jira.greenbone.net/browse/GEA-1139


