### PR TITLE
Fix job summary with multi line content

### DIFF
--- a/create-multi-arch-container-image/action.yml
+++ b/create-multi-arch-container-image/action.yml
@@ -95,8 +95,9 @@ runs:
       if: ${{ inputs.summary == 'true' }}
       shell: bash
       run: |
+        out='${{ steps.inspect.outputs.summary }}'
         echo "## Multi-Arch Container Image Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY"
-        echo "${{ steps.inspect.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
+        echo "$out" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY"


### PR DESCRIPTION


## What
Fix job summary with multi line content

## Why

echo doesn't handle multi line content correctly. Therefore put the content into a shell variable first.

