### PR TITLE
Fix: manifest action muti project upload

### DIFF
--- a/container-multi-arch-manifest/action.yaml
+++ b/container-multi-arch-manifest/action.yaml
@@ -99,7 +99,7 @@ runs:
           exit 1
         fi
         # Get manifest digest
-        manifest_digest=$(echo "$out" | grep -o 'sha256:[a-f0-9]\{64\}' | sort -u)
+        manifest_digest=$(echo "$out" | tail -2 | grep -o 'sha256:[a-f0-9]\{64\}' | sort -u)
         set -e
         # Check manifest digest
         if ! [ "$manifest_digest" ]; then


### PR DESCRIPTION
## What
 Fix: manifest action muti project upload #1465 
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
On a multi repository upload the docker buildx output containes multible digest's from multible container layers. We have to grep the digest from the last two lines.
<!-- Describe why are these changes necessary? -->

## References

- [DEVOPS-1681](https://jira.greenbone.net/browse/DEVOPS-1681)



