### PR TITLE
Improve pypi-upload action

### DIFF
--- a/pypi-upload/action.yaml
+++ b/pypi-upload/action.yaml
@@ -27,29 +27,15 @@ runs:
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Install pip and uv
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade uv
-      shell: bash
-    - name: Install dependencies and sync environment
-      run: |
-        uv sync
-      shell: bash
+    - name: Install uv
+      uses: greenbone/actions/uv@v3
+      with:
+        python-version: ${{ inputs.python-version }}
     - name: Build
       run: |
         uv build
       shell: bash
-    - name: Verify package metadata
-      run: |
-        python -m pip install --upgrade twine
-        python -m twine check dist/*
-      shell: bash
     - name: Upload
-      run: |
-        if [ -n "${{ inputs.pypi-token }}" ]; then
-          python -m twine upload dist/* --username __token__ --password "${{ inputs.pypi-token }}"
-        else
-          echo "No PyPI token provided, skipping upload"
-        fi
-      shell: bash
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      with:
+        password: ${{ inputs.pypi-token }}


### PR DESCRIPTION


## What

Improve pypi-upload action

## Why

* Install uv via our own action
* Run uv build only
* Use pypa action to upload the dist files to pypi again


