### PR TITLE
Change: Remove if conditions from sign-release-files action

### DIFF
--- a/sign-release-files/action.yml
+++ b/sign-release-files/action.yml
@@ -96,13 +96,11 @@ runs:
         gpg --pinentry-mode loopback --passphrase ${{ inputs.gpg-passphrase }} --import tmp.file
         rm tmp.file
       shell: bash
-      if: ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
     # Signing
     - name: Sign files for released version
       run: |
         echo "Signing release files"
         pontos-release sign ${{ env.ARGS }} --repository ${{ inputs.repository }} --signing-key ${{ inputs.gpg-fingerprint }} --passphrase ${{ inputs.gpg-passphrase }} --versioning-scheme ${{ inputs.versioning-scheme }} --git-tag-prefix ${{ inputs.git-tag-prefix }}
       shell: bash
-      if: ${{ inputs.sign-release-files == 'true' }} && ${{ inputs.gpg-key }} && ${{ inputs.gpg-fingerprint }} && ${{ inputs.gpg-passphrase }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
## What

<!--
Removes the `if` conditions from the *Sign files for
released version* steps in `sign-release-files/action.yml`.
-->


Removes the `if` conditions from the *Import gpg key from secrets* and *Sign files for
released version* steps in `sign-release-files/action.yml`.

## Why

Both conditions mix `${{ }}` blocks with `&&` operators outside of them:

```yaml
if: ${{ inputs.sign-release-files == 'true' }} && ${{ inputs.gpg-key }} && ...
```

GitHub doesn't evaluate that form as a boolean expression, so both conditions are always
truthy and never filtered anything.

The one on the signing step also checks [`inputs.sign-release-files`](https://github.com/greenbone/actions/blob/main/sign-release-files/action.yml#L106), which isn't declared in
the corresponding action's inputs.

## Why remove them instead of fixing the syntax

The three GPG inputs are already validated right above, at lines 45-62:

```yaml
- name: Check gpg-key input
  if: inputs.gpg-key == ''
  run: |
    echo "::error ::gpg-key input is missing."
    exit 1
```

Those steps fail the action when an input is missing, so the three are guaranteed to be set
by the time the signing step runs. And whether to sign at all is already decided by the
caller, in [`release/action.yaml:244`.](https://github.com/greenbone/actions/blob/main/release/action.yaml#L244)

Fixing only the syntax would also make `'' == 'true'` evaluate to `false` and **skip signing
entirely.**

## Behaviour change

None. Both conditions always evaluated to `true`, so both steps already ran unconditionally
and keep doing exactly that — the conditions were a no-op. Release files are being signed
today; this only removes a check that never had any effect.

---

This is my first contribution here, so please let me know if I've missed context on why the
conditions were there.

I noticed the same `${{ }} && ${{ }}` pattern in `release/action.yaml:115`. That one has no
preceding validation steps, so the fix there would be different — happy to open a separate PR
if it's useful.

Kind regards,

Max.

