### PR TITLE
Fix handling of empty SSH cmd-output

### DIFF
--- a/ssh-run-cmd/action.yaml
+++ b/ssh-run-cmd/action.yaml
@@ -44,19 +44,23 @@ runs:
         known_hosts: ${{ inputs.known-hosts }}
     - name: Run bash cmd on remote host
       if: ${{ inputs.cmd }}
+      env:
+        CMD_OUTPUT: ${{ inputs.cmd-output }}
       run: |
-        if [ -z "${{ inputs.cmd-output }}" ]; then
+        if [ -z "$CMD_OUTPUT" ]; then
           echo '${{ inputs.cmd }}' | ssh ${{ inputs.ssh-user }}@${{ inputs.ssh-remote-host }} -i '${{ inputs.ssh-tmp }}/key.ssh' /bin/bash
         else
-          echo '${{ inputs.cmd }}' | ssh ${{ inputs.ssh-user }}@${{ inputs.ssh-remote-host }} -i '${{ inputs.ssh-tmp }}/key.ssh' /bin/bash > ${{ inputs.cmd-output }}
+          echo '${{ inputs.cmd }}' | ssh ${{ inputs.ssh-user }}@${{ inputs.ssh-remote-host }} -i '${{ inputs.ssh-tmp }}/key.ssh' /bin/bash > "$CMD_OUTPUT"
         fi
       shell: bash
     - name: Run bash cmd on remote host
       if: ${{ inputs.file }}
+      env:
+        CMD_OUTPUT: ${{ inputs.cmd-output }}
       run: |
-        if [ -z "${{ inputs.cmd-output }}" ]; then
+        if [ -z "$CMD_OUTPUT" ]; then
           ssh ${{ inputs.ssh-user }}@${{ inputs.ssh-remote-host }} -i '${{ inputs.ssh-tmp }}/key.ssh' 'bash -s' < ${{ inputs.file }}
         else
-          ssh ${{ inputs.ssh-user }}@${{ inputs.ssh-remote-host }} -i '${{ inputs.ssh-tmp }}/key.ssh' 'bash -s' < ${{ inputs.file }} > ${{ inputs.cmd-output }}
+          ssh ${{ inputs.ssh-user }}@${{ inputs.ssh-remote-host }} -i '${{ inputs.ssh-tmp }}/key.ssh' 'bash -s' < ${{ inputs.file }} > "$CMD_OUTPUT"
         fi
       shell: bash


### PR DESCRIPTION
## What and Why

Use an environment variable for the `cmd-output` input. Otherwise, workflows using the default empty value of this input will encounter failures before any command is executed due GitHub interpolation happening before bash execution.

## References

#1513 
