### PR TITLE
Change: Skip unnecessary clone in mattermost-notify

### DIFF
--- a/mattermost-notify/action.yml
+++ b/mattermost-notify/action.yml
@@ -82,7 +82,7 @@ runs:
     - name: Checkout
       # we need a checkout to determine the commit-message per git
       # if commit is set but commit-message is not
-      if: inputs.commit && !inputs.commit-message
+      if: inputs.commit && !inputs.commit-message && !inputs.message
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.commit }}
@@ -102,6 +102,7 @@ runs:
         echo "POS_ARGS=${{ inputs.MATTERMOST_WEBHOOK_URL }}${{ inputs.url }} ${{ inputs.MATTERMOST_CHANNEL }}${{ inputs.channel }}" >> $GITHUB_ENV
 
     - name: Inputs for Github success notifications
+      if: ${{ !inputs.message }}
       shell: bash
       run: |
         ARGS=()


### PR DESCRIPTION
## What
This PR improves the runtime of the mattermost-notify action by skipping cloning the repo, when it's unnecessary.

## Why
In the VTs repository we have multiple workflow jobs (e.g. https://github.com/greenbone/vulnerability-tests/actions/runs/31194419013/job/92923537954#step:2:1 or https://github.com/greenbone/vulnerability-tests/actions/runs/31365543906/job/93384952309#step:2:1), which only send out a notification using `message` input variable.

We are not using any of the magic to automatically create the message by commit ID and should therefore stop cloning the repo, when it's not needed.
In our use-case, this should save about 60%+ of runtime, so from over 1 minute down to ~25 sec.

## References
Closes https://jira.greenbone.net/browse/VTOPS-450

## Checklist
Test with message: https://github.com/greenbone/vulnerability-tests/actions/runs/31393409358/job/93470372256 (25 sec. in total)
Test without message (so with clone for automatic message): https://github.com/greenbone/vulnerability-tests/actions/runs/31393516162/job/93470715583 (1:06 min in total)
