### PR TITLE
Allow to override the rust component to install by default

### DIFF
--- a/setup-rust/README.md
+++ b/setup-rust/README.md
@@ -25,6 +25,7 @@ jobs:
 
 ## Action Configuration
 
-| Input        | Description                                       |                                |
-| ------------ | ------------------------------------------------- | ------------------------------ |
-| rust-version | The rust version to setup, for example `nightly`. | Optional (default is `stable`) |
+| Input        | Description                                       |                                        |
+| ------------ | ------------------------------------------------- | -------------------------------------- |
+| rust-version | The rust version to setup, for example `nightly`. | Optional (default is `stable`)         |
+| components   | Additional components to install.                 | Optional (default is `rustfmt clippy`) |

--- a/setup-rust/action.yml
+++ b/setup-rust/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: "The Rust version to install (default: stable)"
     required: false
     default: "stable"
+  components:
+    description: "Additional Rust components to install (default: rustfmt clippy)"
+    required: false
+    default: "rustfmt clippy"
 
 runs:
   using: "composite"
@@ -27,5 +31,5 @@ runs:
       run: rustc --version
       shell: bash
     - name: Ensure linting and formatting tools are installed
-      run: rustup component add rustfmt clippy
+      run: rustup component add ${{ inputs.components }}
       shell: bash

--- a/setup-rust/action.yml
+++ b/setup-rust/action.yml
@@ -25,11 +25,15 @@ runs:
           target/
         key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Set up Rust
-      run: rustup update ${{ inputs.rust-version }} && rustup default ${{ inputs.rust-version }} || rustup default ${{ inputs.rust-version }}
+      run: rustup update "$INPUTS_RUST_VERSION" && rustup default "$INPUTS_RUST_VERSION" || rustup default "$INPUTS_RUST_VERSION"
       shell: bash
+      env:
+        INPUTS_RUST_VERSION: ${{ inputs.rust-version }}
     - name: Print Rust compiler version
       run: rustc --version
       shell: bash
     - name: Ensure linting and formatting tools are installed
-      run: rustup component add ${{ inputs.components }}
+      run: rustup component add "$INPUTS_COMPONENTS"
+      env:
+        INPUTS_COMPONENTS: ${{ inputs.components }}
       shell: bash


### PR DESCRIPTION


## What

Allow to override the rust component to install by default

## Why

Currently `rustfmt` and `clippy` are installed by default. To not install them the components input can be set to an empty string.


