### PR TITLE
Fix installing the desired rust components

### DIFF
--- a/setup-rust/action.yml
+++ b/setup-rust/action.yml
@@ -32,8 +32,11 @@ runs:
     - name: Print Rust compiler version
       run: rustc --version
       shell: bash
-    - name: Ensure linting and formatting tools are installed
-      run: rustup component add "$INPUTS_COMPONENTS"
+    - name: Install additional Rust components
+      run: |
+        set -euo pipefail
+        read -r -a components <<< "$INPUTS_COMPONENTS"
+        rustup component add -- "${components[@]}"
       env:
         INPUTS_COMPONENTS: ${{ inputs.components }}
       shell: bash


### PR DESCRIPTION


## What

Fix installing the desired rust components

## Why

Quoting the whole input argument doesn't work because rustup will interpret the whole string as a single argument and therefore as a single component.

Instead parse the input arguments into an array and using `"${components[@]}"` ensures that each component will be quoted correctly. Additionally using `--` will ensure that a component will not be interpreted as an argument for rustup.

