### PR TITLE
fix(download-artifact): respect older artifact search setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,18 @@ updates:
           - "*"
 
   - package-ecosystem: "github-actions"
+    directory: "/auto-merge"
+    schedule:
+      interval: "weekly"
+      time: "04:00"
+    commit-message:
+      prefix: "Deps"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
     directory: "/awx-run"
     schedule:
       interval: "weekly"

--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -215,10 +215,8 @@ class DownloadArtifacts:
         if not runs:
             return None, None
 
-        runs = sorted(runs, key=created_at, reverse=True)
         matching_artifacts: list[tuple[WorkflowRun, Artifact]] = []
-
-        for run in runs:
+        for run in sorted(runs, key=created_at, reverse=True):
             artifacts = [
                 artifact
                 async for artifact in self.api.artifacts.get_workflow_run_artifacts(
@@ -226,16 +224,9 @@ class DownloadArtifacts:
                 )
             ]
 
-            if not self.name:
-                artifacts = [
-                    artifact for artifact in artifacts if not artifact.expired
-                ]
-                if artifacts:
-                    return run, artifacts
-                continue
-
+            run_artifacts = []
             for artifact in artifacts:
-                if self.name != artifact.name:
+                if self.name and self.name != artifact.name:
                     Console.log(
                         f"Skipping artifact '{artifact.name} with ID {artifact.id}' "
                         f"because it does not match {self.name}."
@@ -249,7 +240,18 @@ class DownloadArtifacts:
                     )
                     continue
 
-                matching_artifacts.append((run, artifact))
+                run_artifacts.append(artifact)
+
+            if run_artifacts:
+                if not self.name or not self.search_older_runs:
+                    return run, run_artifacts
+
+                matching_artifacts.extend(
+                    (run, artifact) for artifact in run_artifacts
+                )
+
+            if not self.search_older_runs:
+                return None, None
 
         if not matching_artifacts:
             return None, None

--- a/download-artifact/tests/test_artifact.py
+++ b/download-artifact/tests/test_artifact.py
@@ -60,6 +60,7 @@ class DownloadArtifactsTestCase(unittest.IsolatedAsyncioTestCase):
         runs: Iterable[SimpleNamespace],
         artifacts: Dict[int, Iterable[SimpleNamespace]],
         name: str | None = "release-artifact",
+        search_older_runs: bool = False,
     ) -> DownloadArtifacts:
         downloader = object.__new__(DownloadArtifacts)
         downloader.repository = "example/repository"
@@ -68,6 +69,7 @@ class DownloadArtifactsTestCase(unittest.IsolatedAsyncioTestCase):
         downloader.workflow_status = "success"
         downloader.workflow_events = ["schedule"]
         downloader.name = name
+        downloader.search_older_runs = search_older_runs
         downloader.is_debug = False
         downloader.api = SimpleNamespace(
             workflows=Workflows(runs), artifacts=Artifacts(artifacts)
@@ -92,7 +94,7 @@ class DownloadArtifactsTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(run.id, new_run.id)
         self.assertEqual([artifact.id for artifact in artifacts], [20])
 
-    async def test_uses_artifact_timestamp_when_runs_are_unordered(
+    async def test_selects_newest_run_when_runs_are_unordered(
         self,
     ) -> None:
         older_artifact_run = workflow_run(1, 25)
@@ -107,6 +109,7 @@ class DownloadArtifactsTestCase(unittest.IsolatedAsyncioTestCase):
                     artifact(20, "release-artifact", 25),
                 ],
             },
+            search_older_runs=True,
         )
 
         run, artifacts = await downloader.get_newest_workflow_run()
@@ -126,12 +129,31 @@ class DownloadArtifactsTestCase(unittest.IsolatedAsyncioTestCase):
                 new_run.id: [artifact(20, "expired", 25, expired=True)],
             },
             name=None,
+            search_older_runs=True,
         )
 
         run, artifacts = await downloader.get_newest_workflow_run()
 
         self.assertEqual(run.id, old_run.id)
         self.assertEqual([artifact.id for artifact in artifacts], [10])
+
+    async def test_does_not_search_older_runs_by_default(self) -> None:
+        old_run = workflow_run(1, 24)
+        new_run = workflow_run(2, 25)
+        downloader = self.downloader(
+            [old_run, new_run],
+            {
+                old_run.id: [artifact(10, "release-artifact", 24)],
+                new_run.id: [
+                    artifact(20, "release-artifact", 25, expired=True),
+                ],
+            },
+        )
+
+        run, artifacts = await downloader.get_newest_workflow_run()
+
+        self.assertIsNone(run)
+        self.assertIsNone(artifacts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restore the search-older-runs behavior so downloads do not silently select artifacts from older workflow runs.

Generated with the help of `pi` coding agent harness (model: github-copilot/gpt-5.6-terra).



