### PR TITLE
Add workflow pagination diagnostics for download-artifact

### DIFF
--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -61,6 +61,19 @@ def workflow_run_page_item(run: dict) -> dict:
     }
 
 
+def workflow_run_request(request: httpx.Request) -> dict:
+    return {
+        "method": request.method,
+        "url": str(request.url),
+        "headers": {
+            name: value
+            for name, value in request.headers.items()
+            if name.lower() != "authorization"
+        },
+        "content": request.content.decode(errors="replace"),
+    }
+
+
 def parse_list(value: str) -> List[str]:
     """
     Parse a csv line into a list of strings.
@@ -209,6 +222,12 @@ class DownloadArtifacts:
                     "workflow-runs-page "
                     + json.dumps(
                         {
+                            "request": workflow_run_request(response.request),
+                            "response": {
+                                "status_code": response.status_code,
+                                "headers": dict(response.headers),
+                                "body": response.json(),
+                            },
                             "request_url": str(request_url),
                             "status_code": response.status_code,
                             "request_id": response.headers.get(

--- a/download-artifact/action/artifact.py
+++ b/download-artifact/action/artifact.py
@@ -51,6 +51,16 @@ def artifact_created_at(artifact: Artifact) -> datetime:
     return artifact.created_at
 
 
+def workflow_run_page_item(run: dict) -> dict:
+    return {
+        "id": run.get("id"),
+        "created_at": run.get("created_at"),
+        "event": run.get("event"),
+        "status": run.get("status"),
+        "url": run.get("html_url"),
+    }
+
+
 def parse_list(value: str) -> List[str]:
     """
     Parse a csv line into a list of strings.
@@ -170,6 +180,8 @@ class DownloadArtifacts:
         self.is_debug = env.is_debug
 
         self.api = GitHubAsyncRESTApi(token)
+        if self.is_debug:
+            self._enable_workflow_run_page_diagnostics()
 
         with Console.group("Settings"):
             Console.log(f"repository: {self.repository}")
@@ -183,6 +195,46 @@ class DownloadArtifacts:
             Console.log(f"search-older-runs: {self.search_older_runs}")
             Console.log(f"user: {self.user}")
             Console.log(f"group: {self.group}")
+
+    def _enable_workflow_run_page_diagnostics(self) -> None:
+        """Log GitHub workflow-run pagination responses in debug mode only."""
+        get = self.api._client.get  # pylint: disable=protected-access
+
+        async def debug_get(*args, **kwargs):
+            response = await get(*args, **kwargs)
+            request_url = response.request.url
+            if request_url.path.endswith("/runs"):
+                workflow_runs = response.json().get("workflow_runs", [])
+                Console.debug(
+                    "workflow-runs-page "
+                    + json.dumps(
+                        {
+                            "request_url": str(request_url),
+                            "status_code": response.status_code,
+                            "request_id": response.headers.get(
+                                "x-github-request-id"
+                            ),
+                            "next_url": response.links.get("next", {}).get(
+                                "url"
+                            ),
+                            "run_count": len(workflow_runs),
+                            "first_run": (
+                                workflow_run_page_item(workflow_runs[0])
+                                if workflow_runs
+                                else None
+                            ),
+                            "last_run": (
+                                workflow_run_page_item(workflow_runs[-1])
+                                if workflow_runs
+                                else None
+                            ),
+                        },
+                        default=str,
+                    )
+                )
+            return response
+
+        self.api._client.get = debug_get  # pylint: disable=protected-access
 
     async def get_newest_workflow_run(
         self,
@@ -207,9 +259,21 @@ class DownloadArtifacts:
             raise DownloadArtifactsError(f"Could not find workflow. {e}") from e
 
         if self.is_debug:
-            urls = "\n".join([run.html_url for run in runs])
             Console.debug(
-                f"Workflow runs for events {self.workflow_events}:\n{urls}"
+                "workflow-run-candidates "
+                + json.dumps(
+                    [
+                        {
+                            "id": run.id,
+                            "created_at": run.created_at,
+                            "event": run.event.value,
+                            "status": run.status.value,
+                            "url": run.html_url,
+                        }
+                        for run in sorted(runs, key=created_at, reverse=True)
+                    ],
+                    default=str,
+                )
             )
 
         if not runs:
@@ -223,6 +287,25 @@ class DownloadArtifacts:
                     self.repository, run.id
                 )
             ]
+            if self.is_debug:
+                Console.debug(
+                    "workflow-run-artifacts "
+                    + json.dumps(
+                        {
+                            "run_id": run.id,
+                            "artifacts": [
+                                {
+                                    "id": artifact.id,
+                                    "name": artifact.name,
+                                    "created_at": artifact.created_at,
+                                    "expired": artifact.expired,
+                                }
+                                for artifact in artifacts
+                            ],
+                        },
+                        default=str,
+                    )
+                )
 
             run_artifacts = []
             for artifact in artifacts:

--- a/download-artifact/tests/test_artifact.py
+++ b/download-artifact/tests/test_artifact.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import json
 import unittest
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Dict, Iterable
+from unittest.mock import patch
 
-from action.artifact import DownloadArtifacts
+import httpx
+
+from action.artifact import DownloadArtifacts, workflow_run_page_item
 
 
 def timestamp(day: int) -> datetime:
@@ -52,6 +56,79 @@ class Artifacts:
         del repository
         for stored_artifact in self.artifacts[run_id]:
             yield stored_artifact
+
+
+class WorkflowRunPageItemTestCase(unittest.TestCase):
+    def test_includes_only_pagination_diagnostic_fields(self) -> None:
+        item = workflow_run_page_item(
+            {
+                "id": 42,
+                "created_at": "2026-08-28T08:30:35Z",
+                "event": "schedule",
+                "status": "completed",
+                "html_url": "https://example.invalid/runs/42",
+                "unrelated": "not logged",
+            }
+        )
+
+        self.assertEqual(
+            item,
+            {
+                "id": 42,
+                "created_at": "2026-08-28T08:30:35Z",
+                "event": "schedule",
+                "status": "completed",
+                "url": "https://example.invalid/runs/42",
+            },
+        )
+
+
+class WorkflowRunPageDiagnosticsTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_logs_pagination_response_without_unrelated_fields(
+        self,
+    ) -> None:
+        response = SimpleNamespace(
+            request=SimpleNamespace(
+                url=httpx.URL(
+                    "https://api.github.com/repos/example/repository/"
+                    "actions/workflows/publish.yml/runs?page=2"
+                )
+            ),
+            status_code=200,
+            headers={"x-github-request-id": "request-id"},
+            links={"next": {"url": "https://example.invalid/runs?page=3"}},
+            json=lambda: {
+                "workflow_runs": [
+                    {
+                        "id": 42,
+                        "created_at": "2026-08-28T08:30:35Z",
+                        "event": "schedule",
+                        "status": "completed",
+                        "html_url": "https://example.invalid/runs/42",
+                        "unrelated": "not logged",
+                    }
+                ]
+            },
+        )
+
+        async def get(*args, **kwargs):
+            del args, kwargs
+            return response
+
+        downloader = object.__new__(DownloadArtifacts)
+        downloader.api = SimpleNamespace(_client=SimpleNamespace(get=get))
+        downloader._enable_workflow_run_page_diagnostics()
+
+        with patch("action.artifact.Console.debug") as debug:
+            await downloader.api._client.get("/unused")
+
+        payload = json.loads(
+            debug.call_args.args[0].removeprefix("workflow-runs-page ")
+        )
+        self.assertEqual(payload["request_id"], "request-id")
+        self.assertEqual(payload["run_count"], 1)
+        self.assertEqual(payload["first_run"]["id"], 42)
+        self.assertNotIn("unrelated", payload["first_run"])
 
 
 class DownloadArtifactsTestCase(unittest.IsolatedAsyncioTestCase):

--- a/download-artifact/tests/test_artifact.py
+++ b/download-artifact/tests/test_artifact.py
@@ -84,31 +84,36 @@ class WorkflowRunPageItemTestCase(unittest.TestCase):
 
 
 class WorkflowRunPageDiagnosticsTestCase(unittest.IsolatedAsyncioTestCase):
-    async def test_logs_pagination_response_without_unrelated_fields(
-        self,
-    ) -> None:
+    async def test_logs_full_pagination_request_and_response(self) -> None:
+        response_body = {
+            "workflow_runs": [
+                {
+                    "id": 42,
+                    "created_at": "2026-08-28T08:30:35Z",
+                    "event": "schedule",
+                    "status": "completed",
+                    "html_url": "https://example.invalid/runs/42",
+                    "unrelated": "logged in the full response",
+                }
+            ]
+        }
         response = SimpleNamespace(
             request=SimpleNamespace(
+                method="GET",
                 url=httpx.URL(
                     "https://api.github.com/repos/example/repository/"
                     "actions/workflows/publish.yml/runs?page=2"
-                )
+                ),
+                headers={
+                    "accept": "application/vnd.github+json",
+                    "authorization": "Bearer secret",
+                },
+                content=b"",
             ),
             status_code=200,
             headers={"x-github-request-id": "request-id"},
             links={"next": {"url": "https://example.invalid/runs?page=3"}},
-            json=lambda: {
-                "workflow_runs": [
-                    {
-                        "id": 42,
-                        "created_at": "2026-08-28T08:30:35Z",
-                        "event": "schedule",
-                        "status": "completed",
-                        "html_url": "https://example.invalid/runs/42",
-                        "unrelated": "not logged",
-                    }
-                ]
-            },
+            json=lambda: response_body,
         )
 
         async def get(*args, **kwargs):
@@ -117,15 +122,21 @@ class WorkflowRunPageDiagnosticsTestCase(unittest.IsolatedAsyncioTestCase):
 
         downloader = object.__new__(DownloadArtifacts)
         downloader.api = SimpleNamespace(_client=SimpleNamespace(get=get))
-        downloader._enable_workflow_run_page_diagnostics()
+        downloader._enable_workflow_run_page_diagnostics()  # pylint: disable=protected-access
 
         with patch("action.artifact.Console.debug") as debug:
-            await downloader.api._client.get("/unused")
+            await downloader.api._client.get(  # pylint: disable=protected-access
+                "/unused"
+            )
 
         payload = json.loads(
             debug.call_args.args[0].removeprefix("workflow-runs-page ")
         )
         self.assertEqual(payload["request_id"], "request-id")
+        self.assertEqual(payload["request"]["method"], "GET")
+        self.assertEqual(payload["request"]["content"], "")
+        self.assertNotIn("authorization", payload["request"]["headers"])
+        self.assertEqual(payload["response"]["body"], response_body)
         self.assertEqual(payload["run_count"], 1)
         self.assertEqual(payload["first_run"]["id"], 42)
         self.assertNotIn("unrelated", payload["first_run"])


### PR DESCRIPTION
Add support for more detailed diagnostics of `download-artifact` to pinpoint artifact selection mismatches.

## References

DOS-836

Generated with the help of `pi` coding agent harness (model: openai-codex/gpt-5.6-terra).

